### PR TITLE
fix(influxdb2/client): Send Content-Type headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Bugs
 1. [#22](https://github.com/influxdata/influxdb-client-ruby/pull/22): Fixed batch write
 1. [#28](https://github.com/influxdata/influxdb-client-ruby/pull/28): Correctly parse CSV where multiple results include multiple tables
+1. [#30](https://github.com/influxdata/influxdb-client-ruby/pull/30): Send Content-Type headers
 
 ## 1.1.0 [2020-02-14]
 

--- a/lib/influxdb2/client/delete_api.rb
+++ b/lib/influxdb2/client/delete_api.rb
@@ -64,7 +64,7 @@ module InfluxDB2
       uri = URI.parse(File.join(@options[:url], '/api/v2/delete'))
       uri.query = URI.encode_www_form(org: org_param, bucket: bucket_param)
 
-      _post(delete_request.to_body.to_json, uri)
+      _post_json(delete_request.to_body.to_json, uri)
     end
 
     def _to_rfc3339(time)

--- a/lib/influxdb2/client/query_api.rb
+++ b/lib/influxdb2/client/query_api.rb
@@ -73,7 +73,7 @@ module InfluxDB2
       uri = URI.parse(File.join(@options[:url], '/api/v2/query'))
       uri.query = URI.encode_www_form(org: org_param)
 
-      _post(payload.to_body.to_json, uri)
+      _post_json(payload.to_body.to_json, uri)
     end
 
     def _generate_payload(query, dialect)

--- a/lib/influxdb2/client/write_api.rb
+++ b/lib/influxdb2/client/write_api.rb
@@ -163,7 +163,7 @@ module InfluxDB2
       uri = URI.parse(File.join(@options[:url], '/api/v2/write'))
       uri.query = URI.encode_www_form(bucket: bucket_param, org: org_param, precision: precision_param.to_s)
 
-      _post(payload, uri)
+      _post_text(payload, uri)
     end
 
     # Item for batching queue

--- a/test/influxdb/delete_api_test.rb
+++ b/test/influxdb/delete_api_test.rb
@@ -112,7 +112,8 @@ class DeleteApiTest < MiniTest::Test
     body = '{"start":"2019-02-03T04:05:06+07:00","stop":"2019-04-03T04:05:06+07:00"}'
     headers = {
       'Authorization' => 'Token my-token',
-      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}"
+      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}",
+      'Content-Type' => 'application/json'
     }
     assert_requested(:post, 'http://localhost:9999/api/v2/delete?bucket=my-bucket&org=my-org',
                      times: 1, body: body, headers: headers)

--- a/test/influxdb/query_api_test.rb
+++ b/test/influxdb/query_api_test.rb
@@ -73,7 +73,7 @@ class QueryApiTest < MiniTest::Test
     assert_equal 'free', record1.field
   end
 
-  def test_user_agent_header
+  def test_headers
     stub_request(:post, 'http://localhost:9999/api/v2/query?org=my-org')
       .to_return(body: SUCCESS_DATA)
 
@@ -87,7 +87,8 @@ class QueryApiTest < MiniTest::Test
 
     headers = {
       'Authorization' => 'Token my-token',
-      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}"
+      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}",
+      'Content-Type' => 'application/json'
     }
     assert_requested(:post, 'http://localhost:9999/api/v2/query?org=my-org',
                      times: 1, headers: headers)

--- a/test/influxdb/write_api_test.rb
+++ b/test/influxdb/write_api_test.rb
@@ -252,7 +252,7 @@ class WriteApiTest < MiniTest::Test
     assert_equal 'The time precision not_supported is not supported.', error.message
   end
 
-  def test_user_agent_header
+  def test_headers
     stub_request(:any, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
       .to_return(status: 204)
 
@@ -266,7 +266,8 @@ class WriteApiTest < MiniTest::Test
 
     headers = {
       'Authorization' => 'Token my-token',
-      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}"
+      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}",
+      'Content-Type' => 'text/plain'
     }
     assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 1, body: 'h2o,location=west value=33i 15', headers: headers)


### PR DESCRIPTION
We recently started requiring `Content-Type` headers in InfluxDB 2.x API. This ensures the client is sending the appropriate headers.

- [x] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] Tests pass
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)