### PR TITLE
Update readme for InfluxDB 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 This repository contains the reference Ruby client for the InfluxDB 2.0.
 
-#### Note: This library is for use with InfluxDB 2.x. For connecting to InfluxDB 1.x instances, please use the [influxdb-ruby](https://github.com/influxdata/influxdb-ruby) client.
+#### Note: Use this client library with InfluxDB 2.x and InfluxDB 1.8+. For connecting to InfluxDB 1.7 or earlier instances, please use the [influxdb-ruby](https://github.com/influxdata/influxdb-ruby) client library.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 This repository contains the reference Ruby client for the InfluxDB 2.0.
 
-#### Note: Use this client library with InfluxDB 2.x and InfluxDB 1.8+. For connecting to InfluxDB 1.7 or earlier instances, please use the [influxdb-ruby](https://github.com/influxdata/influxdb-ruby) client library.
+#### Note: Use this client library with InfluxDB 2.x and InfluxDB 1.8+. For connecting to InfluxDB 1.7 or earlier instances, use the [influxdb-ruby](https://github.com/influxdata/influxdb-ruby) client library.
 
 ## Installation
 


### PR DESCRIPTION
Closes #34
Update readme statement to reflect this client library supports 2.0 and 1.8+.

[NA] CHANGELOG.md updated (not applicable)
[X]  Rebased/mergeable