### PR TITLE
fix: serialization of `\n`, `\r` and `\t` to Line Protocol,  `=` is valid sign for measurement name 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.6.0 [unreleased]
 
+### Bug Fixes
+1. [#42](https://github.com/influxdata/influxdb-client-ruby/pull/42): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
+
 ## 1.5.0 [2020-06-19]
 
 ### API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.6.0 [unreleased]
 
 ### Bug Fixes
-1. [#42](https://github.com/influxdata/influxdb-client-ruby/pull/42): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol 
+1. [#42](https://github.com/influxdata/influxdb-client-ruby/pull/42): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name  
 
 ## 1.5.0 [2020-06-19]
 

--- a/lib/influxdb2/client/point.rb
+++ b/lib/influxdb2/client/point.rb
@@ -21,6 +21,7 @@
 module InfluxDB2
   DEFAULT_WRITE_PRECISION = WritePrecision::NANOSECOND
   ESCAPE_KEY_LIST = ['\\'.freeze, ','.freeze, ' '.freeze, '='.freeze].freeze
+  REPLACE_KEY_LIST = { "\n".freeze => '\n'.freeze, "\r".freeze => '\r'.freeze, "\t".freeze => '\t'.freeze }.freeze
   ESCAPE_VALUE_LIST = ['\\'.freeze, '"'.freeze].freeze
 
   # Point defines the values that will be written to the database.
@@ -165,6 +166,9 @@ module InfluxDB2
       result = value.dup
       ESCAPE_KEY_LIST.each do |ch|
         result = result.gsub(ch) { "\\#{ch}" }
+      end
+      REPLACE_KEY_LIST.keys.each do |ch|
+        result = result.gsub(ch) { REPLACE_KEY_LIST[ch] }
       end
       result
     end

--- a/lib/influxdb2/client/point.rb
+++ b/lib/influxdb2/client/point.rb
@@ -21,6 +21,7 @@
 module InfluxDB2
   DEFAULT_WRITE_PRECISION = WritePrecision::NANOSECOND
   ESCAPE_KEY_LIST = ['\\'.freeze, ','.freeze, ' '.freeze, '='.freeze].freeze
+  ESCAPE_MEASUREMENT_LIST = ['\\'.freeze, ','.freeze, ' '.freeze].freeze
   REPLACE_KEY_LIST = { "\n".freeze => '\n'.freeze, "\r".freeze => '\r'.freeze, "\t".freeze => '\t'.freeze }.freeze
   ESCAPE_VALUE_LIST = ['\\'.freeze, '"'.freeze].freeze
 
@@ -114,7 +115,7 @@ module InfluxDB2
     # @return a string representation of the point
     def to_line_protocol
       line_protocol = ''
-      measurement = _escape_key(@name || '')
+      measurement = _escape_key(@name || '', ESCAPE_MEASUREMENT_LIST)
 
       line_protocol << measurement
 
@@ -162,9 +163,9 @@ module InfluxDB2
       end.reject(&:nil?).join(','.freeze)
     end
 
-    def _escape_key(value)
+    def _escape_key(value, escape_list = ESCAPE_KEY_LIST)
       result = value.dup
-      ESCAPE_KEY_LIST.each do |ch|
+      escape_list.each do |ch|
         result = result.gsub(ch) { "\\#{ch}" }
       end
       REPLACE_KEY_LIST.keys.each do |ch|

--- a/test/influxdb/point_test.rb
+++ b/test/influxdb/point_test.rb
@@ -218,4 +218,17 @@ class PointTest < MiniTest::Test
 
     assert_equal 'h2o level=2i 123', point.to_line_protocol
   end
+
+  def test_tag_escaping
+    point = InfluxDB2::Point.new(name: "h\n2\ro\t_data")
+                            .add_tag("new\nline", "new\nline")
+                            .add_tag("carriage\rreturn", "carriage\nreturn")
+                            .add_tag("t\tab", "t\tab")
+                            .add_field('level', 2)
+
+    puts point.to_line_protocol
+
+    assert_equal 'h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\nreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i',
+                 point.to_line_protocol
+  end
 end

--- a/test/influxdb/point_test.rb
+++ b/test/influxdb/point_test.rb
@@ -231,4 +231,12 @@ class PointTest < MiniTest::Test
     assert_equal 'h\\n2\\ro\\t_data,carriage\\rreturn=carriage\\nreturn,new\\nline=new\\nline,t\\tab=t\\tab level=2i',
                  point.to_line_protocol
   end
+
+  def test_equal_sign_escaping
+    point = InfluxDB2::Point.new(name: 'h=2o')
+                            .add_tag('l=ocation', 'e=urope')
+                            .add_field('l=evel', 2)
+
+    assert_equal 'h=2o,l\\=ocation=e\\=urope l\\=evel=2i', point.to_line_protocol
+  end
 end


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-client-java/issues/127

* serialization of `\n`, `\r` and `\t` to Line Protocol
* `=` is valid sign for measurement name 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)