### PR TITLE
fix: Remove `positive?` breaking in Ruby 2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#42](https://github.com/influxdata/influxdb-client-ruby/pull/42): Fixed serialization of `\n`, `\r` and `\t` to Line Protocol, `=` is valid sign for measurement name  
+1. [#44](https://github.com/influxdata/influxdb-client-ruby/pull/44): Fixed supporting of Ruby 2.2
 
 ## 1.5.0 [2020-06-19]
 

--- a/lib/influxdb2/client/worker.rb
+++ b/lib/influxdb2/client/worker.rb
@@ -99,7 +99,7 @@ module InfluxDB2
     end
 
     def _write_raw(key, points)
-      if @write_options.jitter_interval.positive?
+      if @write_options.jitter_interval > 0
         jitter_delay = (@write_options.jitter_interval.to_f / 1_000) * rand
         sleep jitter_delay
       end


### PR DESCRIPTION
Closes #43 

_Briefly describe your proposed changes:_
Removes `.positive?` method, which is not supported in Ruby 2.2, in favor of basic comparison to zero.

EDIT: noticing that spec coverage is only for Ruby 2.4 and up, but gemspec supports >= Ruby 2.2.

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)