### PR TITLE
feat: Add max_retries, max_retry_delay and exponential_base to WriteApi

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,3 +39,5 @@ Metrics/CyclomaticComplexity:
   Max: 15
 Metrics/PerceivedComplexity:
   Max: 15
+Metrics/ParameterLists:
+  Max: 10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.7.0 [unreleased]
 
+### Features
+1. [#47](https://github.com/influxdata/influxdb-client-ruby/pull/47): Added max_retries and max_retry_delay to WriteApi
+
 ## 1.6.0 [2020-07-17]
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 1.7.0 [unreleased]
 
 ### Features
-1. [#47](https://github.com/influxdata/influxdb-client-ruby/pull/47): Added max_retries and max_retry_delay to WriteApi
+1. [#47](https://github.com/influxdata/influxdb-client-ruby/pull/47): Added max_retries, max_retry_delay and exponential_base to WriteApi
 
 ## 1.6.0 [2020-07-17]
 

--- a/README.md
+++ b/README.md
@@ -125,13 +125,14 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | flush_interval | the number of milliseconds before the batch is written | 1000 |
 | retry_interval | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
 | jitter_interval | the number of milliseconds to increase the batch flush interval by a random amount | 0 |
-| max_retries | the number of max retries when write fails | 3 |
-| max_retry_delay | maximum delay when retrying write in milliseconds | 15000 |
-
+| max_retries | the number of max retries when write fails | 5 |
+| max_retry_delay | maximum delay when retrying write in milliseconds | 180000 |
+| exponential_base | the base for the exponential retry delay, the next delay is computed as `retry_interval * exponential_base^(attempts - 1) + random(jitter_interval)` | 5 |
 ```ruby
 write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
                                             batch_size: 10, flush_interval: 5_000, 
-                                            max_retries: 3, max_retry_delay: 15_000)
+                                            max_retries: 3, max_retry_delay: 15_000,
+                                            exponential_base: 2)
 client = InfluxDB2::Client.new('http://localhost:9999',
                                'my-token',
                                bucket: 'my-bucket',

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | --- | --- | --- |
 | batchSize | the number of data point to collect in batch | 1000 |
 | flush_interval | the number of milliseconds before the batch is written | 1000 |
-| retry_interval | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
+| retry_interval | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header. | 5000 |
 | jitter_interval | the number of milliseconds to increase the batch flush interval by a random amount | 0 |
 | max_retries | the number of max retries when write fails | 5 |
 | max_retry_delay | maximum delay when retrying write in milliseconds | 180000 |

--- a/README.md
+++ b/README.md
@@ -125,10 +125,13 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | flush_interval | the number of milliseconds before the batch is written | 1000 |
 | retry_interval | the number of milliseconds to retry unsuccessful write. The retry interval is used when the InfluxDB server does not specify "Retry-After" header. | 1000 |
 | jitter_interval | the number of milliseconds to increase the batch flush interval by a random amount | 0 |
+| max_retries | the number of max retries when write fails | 3 |
+| max_retry_delay | maximum delay when retrying write in milliseconds | 15000 |
 
 ```ruby
 write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
-                                            batch_size: 10, flush_interval: 5_000)
+                                            batch_size: 10, flush_interval: 5_000, 
+                                            max_retries: 3, max_retry_delay: 15_000)
 client = InfluxDB2::Client.new('http://localhost:9999',
                                'my-token',
                                bucket: 'my-bucket',

--- a/lib/influxdb2/client/default_api.rb
+++ b/lib/influxdb2/client/default_api.rb
@@ -83,6 +83,8 @@ module InfluxDB2
         else
           raise InfluxError.from_response(response)
         end
+      rescue Errno::ECONNREFUSED => e
+        raise InfluxError.from_error(e)
       ensure
         http.finish if http.started?
       end

--- a/lib/influxdb2/client/default_api.rb
+++ b/lib/influxdb2/client/default_api.rb
@@ -83,8 +83,8 @@ module InfluxDB2
         else
           raise InfluxError.from_response(response)
         end
-      rescue Errno::ECONNREFUSED => e
-        raise InfluxError.from_error(e)
+      rescue *InfluxError::HTTP_ERRORS => error
+        raise InfluxError.from_error(error)
       ensure
         http.finish if http.started?
       end

--- a/lib/influxdb2/client/influx_error.rb
+++ b/lib/influxdb2/client/influx_error.rb
@@ -1,17 +1,16 @@
 module InfluxDB2
   # InfluxError that is raised during HTTP communication.
   class InfluxError < StandardError
-
     HTTP_ERRORS = [
-        EOFError,
-        Errno::ECONNREFUSED,
-        Errno::ECONNRESET,
-        Errno::EINVAL,
-        Net::HTTPBadResponse,
-        Net::HTTPHeaderSyntaxError,
-        Net::ProtocolError,
-        Timeout::Error
-    ]
+      EOFError,
+      Errno::ECONNREFUSED,
+      Errno::ECONNRESET,
+      Errno::EINVAL,
+      Net::HTTPBadResponse,
+      Net::HTTPHeaderSyntaxError,
+      Net::ProtocolError,
+      Timeout::Error
+    ].freeze
 
     # HTTP status code
     attr_reader :code

--- a/lib/influxdb2/client/influx_error.rb
+++ b/lib/influxdb2/client/influx_error.rb
@@ -1,38 +1,50 @@
 module InfluxDB2
   # InfluxError that is raised during HTTP communication.
   class InfluxError < StandardError
+
+    HTTP_ERRORS = [
+        EOFError,
+        Errno::ECONNREFUSED,
+        Errno::ECONNRESET,
+        Errno::EINVAL,
+        Net::HTTPBadResponse,
+        Net::HTTPHeaderSyntaxError,
+        Net::ProtocolError,
+        Timeout::Error
+    ]
+
     # HTTP status code
     attr_reader :code
     # Reference code unique to the error type
     attr_reader :reference
     # The Retry-After header describes when to try the request again.
     attr_reader :retry_after
-    # Connection error flag
-    attr_reader :connection_error
+    # original error
+    attr_reader :original
 
-    def initialize(message:, code:, reference:, retry_after:, connection_error:)
+    def initialize(original = nil, message:, code:, reference:, retry_after:)
       super(message)
 
       @code = code
       @reference = reference
       @retry_after = retry_after
-      @connection_error = connection_error
+      @original = original
     end
 
     def self.from_response(response)
       json = JSON.parse(response.body)
       obj = new(message: json['message'] || '', code: response.code, reference: json['code'] || '',
-                retry_after: response['Retry-After'] || '', connection_error: false)
+                retry_after: response['Retry-After'] || '')
       obj
     end
 
     def self.from_message(message)
-      obj = new(message: message, code: '', reference: '', retry_after: '', connection_error: false)
+      obj = new(message: message, code: '', reference: '', retry_after: '')
       obj
     end
 
     def self.from_error(error)
-      obj = new(message: error.message, code: '', reference: '', retry_after: '', connection_error: true)
+      obj = new(error, message: error.message, code: '', reference: '', retry_after: '')
       obj
     end
   end

--- a/lib/influxdb2/client/influx_error.rb
+++ b/lib/influxdb2/client/influx_error.rb
@@ -7,24 +7,32 @@ module InfluxDB2
     attr_reader :reference
     # The Retry-After header describes when to try the request again.
     attr_reader :retry_after
+    # Connection error flag
+    attr_reader :connection_error
 
-    def initialize(message:, code:, reference:, retry_after:)
+    def initialize(message:, code:, reference:, retry_after:, connection_error:)
       super(message)
 
       @code = code
       @reference = reference
       @retry_after = retry_after
+      @connection_error = connection_error
     end
 
     def self.from_response(response)
       json = JSON.parse(response.body)
       obj = new(message: json['message'] || '', code: response.code, reference: json['code'] || '',
-                retry_after: response['Retry-After'] || '')
+                retry_after: response['Retry-After'] || '', connection_error: false)
       obj
     end
 
     def self.from_message(message)
-      obj = new(message: message, code: '', reference: '', retry_after: '')
+      obj = new(message: message, code: '', reference: '', retry_after: '', connection_error: false)
+      obj
+    end
+
+    def self.from_error(error)
+      obj = new(message: error.message, code: '', reference: '', retry_after: '', connection_error: true)
       obj
     end
   end

--- a/lib/influxdb2/client/worker.rb
+++ b/lib/influxdb2/client/worker.rb
@@ -31,6 +31,8 @@ module InfluxDB2
 
       @queue_event.push(true)
 
+      Thread.abort_on_exception = true
+
       @thread_flush = Thread.new do
         until api_client.closed
           sleep @write_options.flush_interval.to_f / 1_000
@@ -94,22 +96,27 @@ module InfluxDB2
 
     def _write(data)
       data.each do |key, points|
-        _write_raw(key, points)
+        _write_raw(key, points, 1, @write_options.retry_interval)
       end
     end
 
-    def _write_raw(key, points)
+    def _write_raw(key, points, attempts, retry_interval)
       if @write_options.jitter_interval > 0
         jitter_delay = (@write_options.jitter_interval.to_f / 1_000) * rand
         sleep jitter_delay
       end
       @api_client.write_raw(points.join("\n"), precision: key.precision, bucket: key.bucket, org: key.org)
     rescue InfluxError => e
-      raise e if e.code.nil? || !(%w[429 503].include? e.code)
+      raise e if e.code.nil? || !(%w[429 503].include? e.code) || attempts > @write_options.max_retries
 
-      timeout = e.retry_after.empty? ? @write_options.retry_interval.to_f / 1_000 : e.retry_after.to_f
+      timeout = if e.retry_after.empty?
+                  [retry_interval.to_f, @write_options.max_retry_delay.to_f].min / 1_000
+                else
+                  e.retry_after.to_f
+                end
+
       sleep timeout
-      _write_raw(key, points)
+      _write_raw(key, points, attempts + 1, retry_interval * 2)
     end
   end
 end

--- a/lib/influxdb2/client/worker.rb
+++ b/lib/influxdb2/client/worker.rb
@@ -121,7 +121,7 @@ module InfluxDB2
     end
 
     def _connection_error(error)
-      InfluxError::HTTP_ERRORS.any? {|c| error.instance_of? c}
+      InfluxError::HTTP_ERRORS.any? { |c| error.instance_of? c }
     end
   end
 end

--- a/lib/influxdb2/client/worker.rb
+++ b/lib/influxdb2/client/worker.rb
@@ -107,7 +107,8 @@ module InfluxDB2
       end
       @api_client.write_raw(points.join("\n"), precision: key.precision, bucket: key.bucket, org: key.org)
     rescue InfluxError => e
-      raise e if ((e.code.nil? || e.code.to_i < 429) && !e.connection_error) || attempts > @write_options.max_retries
+      raise e if attempts > @write_options.max_retries
+      raise e if (e.code.nil? || e.code.to_i < 429) && !_connection_error(e.original)
 
       timeout = if e.retry_after.empty?
                   [retry_interval.to_f, @write_options.max_retry_delay.to_f].min / 1_000
@@ -117,6 +118,10 @@ module InfluxDB2
 
       sleep timeout
       _write_raw(key, points, attempts + 1, retry_interval * @write_options.exponential_base)
+    end
+
+    def _connection_error(error)
+      InfluxError::HTTP_ERRORS.any? {|c| error.instance_of? c}
     end
   end
 end

--- a/lib/influxdb2/client/worker.rb
+++ b/lib/influxdb2/client/worker.rb
@@ -107,7 +107,7 @@ module InfluxDB2
       end
       @api_client.write_raw(points.join("\n"), precision: key.precision, bucket: key.bucket, org: key.org)
     rescue InfluxError => e
-      raise e if e.code.nil? || e.code.to_i < 429 || attempts > @write_options.max_retries
+      raise e if ((e.code.nil? || e.code.to_i < 429) && !e.connection_error) || attempts > @write_options.max_retries
 
       timeout = if e.retry_after.empty?
                   [retry_interval.to_f, @write_options.max_retry_delay.to_f].min / 1_000

--- a/lib/influxdb2/client/write_api.rb
+++ b/lib/influxdb2/client/write_api.rb
@@ -47,6 +47,7 @@ module InfluxDB2
       _check_positive('jitter_interval', jitter_interval)
       _check_positive('max_retries', jitter_interval)
       _check_positive('max_retry_delay', jitter_interval)
+      _check_positive('exponential_base', exponential_base)
       @write_type = write_type
       @batch_size = batch_size
       @flush_interval = flush_interval

--- a/lib/influxdb2/client/write_api.rb
+++ b/lib/influxdb2/client/write_api.rb
@@ -37,8 +37,10 @@ module InfluxDB2
     # @param [Integer] max_retries: max number of retries when write fails
     # @param [Integer] max_retry_delay: maximum delay when retrying write in milliseconds
     #   by a random amount
+    # @param [Integer] exponential_base: base for the exponential retry delay, the next delay is computed as
+    #   "backoff_factor * exponential_base^(attempts-1) + random(jitter_interval)"
     def initialize(write_type: WriteType::SYNCHRONOUS, batch_size: 1_000, flush_interval: 1_000, retry_interval: 1_000,
-                   jitter_interval: 0, max_retries: 3, max_retry_delay: 15_000)
+                   jitter_interval: 0, max_retries: 3, max_retry_delay: 180_000, exponential_base: 5)
       _check_not_negative('batch_size', batch_size)
       _check_not_negative('flush_interval', flush_interval)
       _check_not_negative('retry_interval', retry_interval)
@@ -52,10 +54,11 @@ module InfluxDB2
       @jitter_interval = jitter_interval
       @max_retries = max_retries
       @max_retry_delay = max_retry_delay
+      @exponential_base = exponential_base
     end
 
     attr_reader :write_type, :batch_size, :flush_interval, :retry_interval, :jitter_interval,
-                :max_retries, :max_retry_delay
+                :max_retries, :max_retry_delay, :exponential_base
 
     def _check_not_negative(key, value)
       raise ArgumentError, "The '#{key}' should be positive or zero, but is: #{value}" if value <= 0

--- a/lib/influxdb2/client/write_api.rb
+++ b/lib/influxdb2/client/write_api.rb
@@ -38,9 +38,9 @@ module InfluxDB2
     # @param [Integer] max_retry_delay: maximum delay when retrying write in milliseconds
     #   by a random amount
     # @param [Integer] exponential_base: base for the exponential retry delay, the next delay is computed as
-    #   "backoff_factor * exponential_base^(attempts-1) + random(jitter_interval)"
-    def initialize(write_type: WriteType::SYNCHRONOUS, batch_size: 1_000, flush_interval: 1_000, retry_interval: 1_000,
-                   jitter_interval: 0, max_retries: 3, max_retry_delay: 180_000, exponential_base: 5)
+    #   "exponential_base^(attempts-1) + random(jitter_interval)"
+    def initialize(write_type: WriteType::SYNCHRONOUS, batch_size: 1_000, flush_interval: 1_000, retry_interval: 5_000,
+                   jitter_interval: 0, max_retries: 5, max_retry_delay: 180_000, exponential_base: 5)
       _check_not_negative('batch_size', batch_size)
       _check_not_negative('flush_interval', flush_interval)
       _check_not_negative('retry_interval', retry_interval)

--- a/lib/influxdb2/client/write_api.rb
+++ b/lib/influxdb2/client/write_api.rb
@@ -34,21 +34,28 @@ module InfluxDB2
     # @param [Integer] retry_interval: number of milliseconds to retry unsuccessful write.
     #   The retry interval is used when the InfluxDB server does not specify "Retry-After" header.
     # @param [Integer] jitter_interval: the number of milliseconds to increase the batch flush interval
+    # @param [Integer] max_retries: max number of retries when write fails
+    # @param [Integer] max_retry_delay: maximum delay when retrying write in milliseconds
     #   by a random amount
     def initialize(write_type: WriteType::SYNCHRONOUS, batch_size: 1_000, flush_interval: 1_000, retry_interval: 1_000,
-                   jitter_interval: 0)
+                   jitter_interval: 0, max_retries: 3, max_retry_delay: 15_000)
       _check_not_negative('batch_size', batch_size)
       _check_not_negative('flush_interval', flush_interval)
       _check_not_negative('retry_interval', retry_interval)
       _check_positive('jitter_interval', jitter_interval)
+      _check_positive('max_retries', jitter_interval)
+      _check_positive('max_retry_delay', jitter_interval)
       @write_type = write_type
       @batch_size = batch_size
       @flush_interval = flush_interval
       @retry_interval = retry_interval
       @jitter_interval = jitter_interval
+      @max_retries = max_retries
+      @max_retry_delay = max_retry_delay
     end
 
-    attr_reader :write_type, :batch_size, :flush_interval, :retry_interval, :jitter_interval
+    attr_reader :write_type, :batch_size, :flush_interval, :retry_interval, :jitter_interval,
+                :max_retries, :max_retry_delay
 
     def _check_not_negative(key, value)
       raise ArgumentError, "The '#{key}' should be positive or zero, but is: #{value}" if value <= 0

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -371,4 +371,59 @@ class WriteApiBatchingTest < MiniTest::Test
     assert_equal 'invalid', error.reference
     assert_equal "unable to parse 'h2o_feet, location=coyote_creek water_level=1.0 1': missing tag key", error.message
   end
+
+  def test_max_retries_by_header
+    error_body = '{"code":"temporarily unavailable","message":"Server is temporarily unavailable to accept writes. '\
+                 'The Retry-After header describes when to try the write again."}'
+
+    headers = { 'X-Platform-Error-Code' => 'temporarily unavailable', 'Retry-After' => '3' }
+
+    stub_request(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 429, headers: headers, body: error_body).then # retry
+      .to_return(status: 429, headers: headers, body: error_body).then # retry
+      .to_return(status: 429, headers: headers, body: error_body).then # retry
+      .to_return(status: 429, headers: headers, body: error_body).then # retry
+      .to_return(status: 429, headers: headers, body: error_body) # not called
+
+    point = InfluxDB2::Point.new(name: 'h2o')
+                            .add_tag('location', 'europe')
+                            .add_field('level', 2.0)
+
+    request = 'h2o,location=europe level=2.0'
+
+    write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                batch_size: 1, retry_interval: 2_000, max_retries: 3,
+                                                max_retry_delay: 5_000)
+
+    error = assert_raises InfluxDB2::InfluxError do
+      @client.create_write_api(write_options: write_options).write(data: point)
+
+      sleep(0.5)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 1, body: request)
+
+      sleep(3)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 2, body: request)
+
+      sleep(3)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 3, body: request)
+
+      sleep(3)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 4, body: request)
+
+      sleep(3)
+    end
+
+    assert_equal('429', error.code)
+
+    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 4, body: request)
+  end
 end

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -202,7 +202,7 @@ class WriteApiBatchingTest < MiniTest::Test
     @write_client = @client.create_write_api(write_options: @write_options)
 
     stub_request(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
-        .to_return(status: 204)
+      .to_return(status: 204)
 
     request = "h2o_feet,location=coyote_creek water_level=1.0 1\n" \
                'h2o_feet,location=coyote_creek water_level=2.0 2'

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -211,7 +211,7 @@ class WriteApiBatchingTest < MiniTest::Test
     assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 1, body: request)
 
-    sleep(1)
+    sleep(5)
 
     assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 2, body: request)
@@ -311,7 +311,7 @@ class WriteApiBatchingTest < MiniTest::Test
 
     write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
                                                 batch_size: 1, retry_interval: 2_000, max_retries: 3,
-                                                max_retry_delay: 5_000)
+                                                max_retry_delay: 5_000, exponential_base: 2)
 
     error = assert_raises InfluxDB2::InfluxError do
       @client.create_write_api(write_options: write_options).write(data: point)
@@ -359,7 +359,7 @@ class WriteApiBatchingTest < MiniTest::Test
 
     write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
                                                 batch_size: 1, retry_interval: 2_000, max_retries: 3,
-                                                max_retry_delay: 5_000)
+                                                max_retry_delay: 5_000, exponential_base: 2)
 
     error = assert_raises InfluxDB2::InfluxError do
       @client.create_write_api(write_options: write_options).write(data: 'h2o,location=west value=33i 15')
@@ -393,7 +393,7 @@ class WriteApiBatchingTest < MiniTest::Test
 
     write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
                                                 batch_size: 1, retry_interval: 2_000, max_retries: 3,
-                                                max_retry_delay: 5_000)
+                                                max_retry_delay: 5_000, exponential_base: 2)
 
     error = assert_raises InfluxDB2::InfluxError do
       @client.create_write_api(write_options: write_options).write(data: point)

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -289,4 +289,86 @@ class WriteApiBatchingTest < MiniTest::Test
     assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 1, body: request)
   end
+
+  def test_max_retries
+    error_body = '{"code":"temporarily unavailable","message":"Server is temporarily unavailable to accept writes. '\
+                 'The Retry-After header describes when to try the write again."}'
+
+    headers = { 'X-Platform-Error-Code' => 'temporarily unavailable' }
+
+    stub_request(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 429, headers: headers, body: error_body).then # retry
+      .to_return(status: 429, headers: headers, body: error_body).then # retry
+      .to_return(status: 429, headers: headers, body: error_body).then # retry
+      .to_return(status: 429, headers: headers, body: error_body).then # retry
+      .to_return(status: 429, headers: headers, body: error_body) # not called
+
+    point = InfluxDB2::Point.new(name: 'h2o')
+                            .add_tag('location', 'europe')
+                            .add_field('level', 2.0)
+
+    request = 'h2o,location=europe level=2.0'
+
+    write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                batch_size: 1, retry_interval: 2_000, max_retries: 3,
+                                                max_retry_delay: 5_000)
+
+    error = assert_raises InfluxDB2::InfluxError do
+      @client.create_write_api(write_options: write_options).write(data: point)
+
+      sleep(0.5)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 1, body: request)
+
+      sleep(2)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 2, body: request)
+
+      sleep(4)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 3, body: request)
+
+      sleep(5)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 4, body: request)
+
+      sleep(5)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 4, body: request)
+
+      sleep(5)
+    end
+
+    assert_equal('429', error.code)
+
+    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 4, body: request)
+  end
+
+  def test_influx_exception
+    error_body = '{"code":"invalid","message":"unable to parse '\
+                 '\'h2o_feet, location=coyote_creek water_level=1.0 1\': missing tag key"}'
+
+    stub_request(:any, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 400, headers: { 'X-Platform-Error-Code' => 'invalid' }, body: error_body)
+
+    write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                batch_size: 1, retry_interval: 2_000, max_retries: 3,
+                                                max_retry_delay: 5_000)
+
+    error = assert_raises InfluxDB2::InfluxError do
+      @client.create_write_api(write_options: write_options).write(data: 'h2o,location=west value=33i 15')
+
+      sleep(1)
+    end
+
+    assert_equal '400', error.code
+    assert_equal 'invalid', error.reference
+    assert_equal "unable to parse 'h2o_feet, location=coyote_creek water_level=1.0 1': missing tag key", error.message
+  end
 end

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -187,6 +187,65 @@ class WriteApiBatchingTest < MiniTest::Test
                      'h2o_feet,location=coyote_creek level\\ water_level=3.0 3')
   end
 
+  def test_jitter_interval
+    @client.close!
+
+    @client = InfluxDB2::Client.new('http://localhost:9999',
+                                    'my-token',
+                                    bucket: 'my-bucket',
+                                    org: 'my-org',
+                                    precision: InfluxDB2::WritePrecision::NANOSECOND,
+                                    use_ssl: false)
+
+    @write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                 batch_size: 2, flush_interval: 5_000, jitter_interval: 2_000)
+    @write_client = @client.create_write_api(write_options: @write_options)
+
+    stub_request(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+        .to_return(status: 204)
+
+    request = "h2o_feet,location=coyote_creek water_level=1.0 1\n" \
+               'h2o_feet,location=coyote_creek water_level=2.0 2'
+
+    @write_client.write(data: ['h2o_feet,location=coyote_creek water_level=1.0 1',
+                               'h2o_feet,location=coyote_creek water_level=2.0 2'])
+
+    sleep(0.05)
+
+    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 0, body: request)
+
+    sleep(2)
+
+    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: request)
+  end
+end
+
+class WriteApiRetryStrategyTest < MiniTest::Test
+  def setup
+    WebMock.disable_net_connect!
+
+    @write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                 batch_size: 2, flush_interval: 5_000, retry_interval: 2_000)
+    @client = InfluxDB2::Client.new('http://localhost:9999',
+                                    'my-token',
+                                    bucket: 'my-bucket',
+                                    org: 'my-org',
+                                    precision: InfluxDB2::WritePrecision::NANOSECOND,
+                                    use_ssl: false)
+
+    @write_client = @client.create_write_api(write_options: @write_options)
+  end
+
+  def teardown
+    @client.close!
+
+    assert_equal true, @write_client.closed
+
+    WebMock.reset!
+  end
+
   def test_retry_interval_by_config
     error_body = '{"code":"temporarily unavailable","message":"Token is temporarily over quota. '\
                  'The Retry-After header describes when to try the write again."}'
@@ -254,40 +313,6 @@ class WriteApiBatchingTest < MiniTest::Test
 
     assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 2, body: request)
-  end
-
-  def test_jitter_interval
-    @client.close!
-
-    @client = InfluxDB2::Client.new('http://localhost:9999',
-                                    'my-token',
-                                    bucket: 'my-bucket',
-                                    org: 'my-org',
-                                    precision: InfluxDB2::WritePrecision::NANOSECOND,
-                                    use_ssl: false)
-
-    @write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
-                                                 batch_size: 2, flush_interval: 5_000, jitter_interval: 2_000)
-    @write_client = @client.create_write_api(write_options: @write_options)
-
-    stub_request(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
-      .to_return(status: 204)
-
-    request = "h2o_feet,location=coyote_creek water_level=1.0 1\n" \
-               'h2o_feet,location=coyote_creek water_level=2.0 2'
-
-    @write_client.write(data: ['h2o_feet,location=coyote_creek water_level=1.0 1',
-                               'h2o_feet,location=coyote_creek water_level=2.0 2'])
-
-    sleep(0.05)
-
-    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                     times: 0, body: request)
-
-    sleep(2)
-
-    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                     times: 1, body: request)
   end
 
   def test_max_retries
@@ -425,5 +450,99 @@ class WriteApiBatchingTest < MiniTest::Test
 
     assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 4, body: request)
+  end
+
+  def test_connection_error
+    error_message = 'Failed to open TCP connection to localhost:9999' \
+        '(Connection refused - connect(2) for "localhost" port 9999)'
+
+    stub_request(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_raise(Errno::ECONNREFUSED.new(error_message))
+      .to_raise(Errno::ECONNREFUSED.new(error_message))
+      .to_raise(Errno::ECONNREFUSED.new(error_message))
+      .to_raise(Errno::ECONNREFUSED.new(error_message))
+      .to_raise(Errno::ECONNREFUSED.new(error_message))
+
+    point = InfluxDB2::Point.new(name: 'h2o')
+                            .add_tag('location', 'europe')
+                            .add_field('level', 2.0)
+
+    request = 'h2o,location=europe level=2.0'
+
+    write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                batch_size: 1, retry_interval: 2_000, max_retries: 3,
+                                                max_retry_delay: 5_000, exponential_base: 2)
+
+    error = assert_raises InfluxDB2::InfluxError do
+      @client.create_write_api(write_options: write_options).write(data: point)
+
+      sleep(0.5)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 1, body: request)
+
+      sleep(2)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 2, body: request)
+
+      sleep(4)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 3, body: request)
+
+      sleep(5)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 4, body: request)
+
+      sleep(5)
+
+      assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                       times: 4, body: request)
+
+      sleep(5)
+    end
+
+    assert_equal('Connection refused - ' + error_message, error.message)
+  end
+
+  def test_write_connection_error
+    stub_request(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_raise(Errno::ECONNREFUSED.new(''))
+      .to_raise(Errno::ECONNREFUSED.new(''))
+      .to_return(status: 204)
+
+    point = InfluxDB2::Point.new(name: 'h2o')
+                            .add_tag('location', 'europe')
+                            .add_field('level', 2.0)
+
+    request = 'h2o,location=europe level=2.0'
+
+    write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                batch_size: 1, retry_interval: 2_000, max_retries: 3,
+                                                max_retry_delay: 5_000, exponential_base: 2)
+
+    @client.create_write_api(write_options: write_options).write(data: point)
+
+    sleep(0.5)
+
+    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: request)
+
+    sleep(2)
+
+    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 2, body: request)
+
+    sleep(4)
+
+    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 3, body: request)
+
+    sleep(5)
+
+    assert_requested(:post, 'http://localhost:9999/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 3, body: request)
   end
 end


### PR DESCRIPTION
Closes 

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
