### PR TITLE
fix: abort only worker threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### API
 1. [#50](https://github.com/influxdata/influxdb-client-ruby/pull/50): Default port changed from 9999 -> 8086
  
+### Bug Fixes
+1. [#52](https://github.com/influxdata/influxdb-client-ruby/pull/52): Fixed aborting of background threads
+
 ## 1.7.0 [2020-08-14]
 
 ### Features

--- a/lib/influxdb2/client/worker.rb
+++ b/lib/influxdb2/client/worker.rb
@@ -31,14 +31,13 @@ module InfluxDB2
 
       @queue_event.push(true)
 
-      Thread.abort_on_exception = true
-
       @thread_flush = Thread.new do
         until api_client.closed
           sleep @write_options.flush_interval.to_f / 1_000
           _check_background_queue
         end
       end
+      @thread_flush.abort_on_exception = true
 
       @thread_size = Thread.new do
         until api_client.closed
@@ -46,6 +45,7 @@ module InfluxDB2
           sleep 0.01
         end
       end
+      @thread_size.abort_on_exception = true
     end
 
     def push(payload)


### PR DESCRIPTION
Closes #51 

## Proposed Changes

- avoid to abort all threads

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
