### PR TITLE
feat: default strategy for batching worker is best-effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 1. [#36](https://github.com/influxdata/influxdb-client-ruby/issues/36): Added support for default tags
+1. [#53](https://github.com/influxdata/influxdb-client-ruby/pull/53): Default strategy for batching worker is best-effort
 
 ### API
 1. [#50](https://github.com/influxdata/influxdb-client-ruby/pull/50): Default port changed from 9999 -> 8086

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The writes are processed in batches which are configurable by `WriteOptions`:
 | max_retries | the number of max retries when write fails | 5 |
 | max_retry_delay | maximum delay when retrying write in milliseconds | 180000 |
 | exponential_base | the base for the exponential retry delay, the next delay is computed as `retry_interval * exponential_base^(attempts - 1) + random(jitter_interval)` | 5 |
+| batch_abort_on_exception | the batching worker will be aborted after failed retry strategy | false |
 ```ruby
 write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
                                             batch_size: 10, flush_interval: 5_000, 

--- a/lib/influxdb2/client/worker.rb
+++ b/lib/influxdb2/client/worker.rb
@@ -37,7 +37,7 @@ module InfluxDB2
           _check_background_queue
         end
       end
-      @thread_flush.abort_on_exception = true
+      @thread_flush.abort_on_exception = @write_options.batch_abort_on_exception
 
       @thread_size = Thread.new do
         until api_client.closed
@@ -45,7 +45,7 @@ module InfluxDB2
           sleep 0.01
         end
       end
-      @thread_size.abort_on_exception = true
+      @thread_size.abort_on_exception = @write_options.batch_abort_on_exception
     end
 
     def push(payload)

--- a/lib/influxdb2/client/write_api.rb
+++ b/lib/influxdb2/client/write_api.rb
@@ -39,8 +39,10 @@ module InfluxDB2
     #   by a random amount
     # @param [Integer] exponential_base: base for the exponential retry delay, the next delay is computed as
     #   "exponential_base^(attempts-1) + random(jitter_interval)"
+    # @param [Boolean] batch_abort_on_exception: batching worker will be aborted after failed retry strategy
     def initialize(write_type: WriteType::SYNCHRONOUS, batch_size: 1_000, flush_interval: 1_000, retry_interval: 5_000,
-                   jitter_interval: 0, max_retries: 5, max_retry_delay: 180_000, exponential_base: 5)
+                   jitter_interval: 0, max_retries: 5, max_retry_delay: 180_000, exponential_base: 5,
+                   batch_abort_on_exception: false)
       _check_not_negative('batch_size', batch_size)
       _check_not_negative('flush_interval', flush_interval)
       _check_not_negative('retry_interval', retry_interval)
@@ -56,10 +58,11 @@ module InfluxDB2
       @max_retries = max_retries
       @max_retry_delay = max_retry_delay
       @exponential_base = exponential_base
+      @batch_abort_on_exception = batch_abort_on_exception
     end
 
     attr_reader :write_type, :batch_size, :flush_interval, :retry_interval, :jitter_interval,
-                :max_retries, :max_retry_delay, :exponential_base
+                :max_retries, :max_retry_delay, :exponential_base, :batch_abort_on_exception
 
     def _check_not_negative(key, value)
       raise ArgumentError, "The '#{key}' should be positive or zero, but is: #{value}" if value <= 0

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -338,38 +338,34 @@ class WriteApiRetryStrategyTest < MiniTest::Test
                                                 batch_size: 1, retry_interval: 2_000, max_retries: 3,
                                                 max_retry_delay: 5_000, exponential_base: 2)
 
-    error = assert_raises InfluxDB2::InfluxError do
-      @client.create_write_api(write_options: write_options).write(data: point)
+    @client.create_write_api(write_options: write_options).write(data: point)
 
-      sleep(0.5)
+    sleep(0.5)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 1, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: request)
 
-      sleep(2)
+    sleep(2)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 2, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 2, body: request)
 
-      sleep(4)
+    sleep(4)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 3, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 3, body: request)
 
-      sleep(5)
+    sleep(5)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 4, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 4, body: request)
 
-      sleep(5)
+    sleep(5)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 4, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 4, body: request)
 
-      sleep(5)
-    end
-
-    assert_equal('429', error.code)
+    sleep(5)
 
     assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 4, body: request)
@@ -384,7 +380,8 @@ class WriteApiRetryStrategyTest < MiniTest::Test
 
     write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
                                                 batch_size: 1, retry_interval: 2_000, max_retries: 3,
-                                                max_retry_delay: 5_000, exponential_base: 2)
+                                                max_retry_delay: 5_000, exponential_base: 2,
+                                                batch_abort_on_exception: true)
 
     error = assert_raises InfluxDB2::InfluxError do
       @client.create_write_api(write_options: write_options).write(data: 'h2o,location=west value=33i 15')
@@ -420,33 +417,29 @@ class WriteApiRetryStrategyTest < MiniTest::Test
                                                 batch_size: 1, retry_interval: 2_000, max_retries: 3,
                                                 max_retry_delay: 5_000, exponential_base: 2)
 
-    error = assert_raises InfluxDB2::InfluxError do
-      @client.create_write_api(write_options: write_options).write(data: point)
+    @client.create_write_api(write_options: write_options).write(data: point)
 
-      sleep(0.5)
+    sleep(0.5)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 1, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: request)
 
-      sleep(3)
+    sleep(3)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 2, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 2, body: request)
 
-      sleep(3)
+    sleep(3)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 3, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 3, body: request)
 
-      sleep(3)
+    sleep(3)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 4, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 4, body: request)
 
-      sleep(3)
-    end
-
-    assert_equal('429', error.code)
+    sleep(3)
 
     assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 4, body: request)
@@ -473,38 +466,37 @@ class WriteApiRetryStrategyTest < MiniTest::Test
                                                 batch_size: 1, retry_interval: 2_000, max_retries: 3,
                                                 max_retry_delay: 5_000, exponential_base: 2)
 
-    error = assert_raises InfluxDB2::InfluxError do
-      @client.create_write_api(write_options: write_options).write(data: point)
+    @client.create_write_api(write_options: write_options).write(data: point)
 
-      sleep(0.5)
+    sleep(0.5)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 1, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: request)
 
-      sleep(2)
+    sleep(2)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 2, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 2, body: request)
 
-      sleep(4)
+    sleep(4)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 3, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 3, body: request)
 
-      sleep(5)
+    sleep(5)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 4, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 4, body: request)
 
-      sleep(5)
+    sleep(5)
 
-      assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                       times: 4, body: request)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 4, body: request)
 
-      sleep(5)
-    end
+    sleep(5)
 
-    assert_equal('Connection refused - ' + error_message, error.message)
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 4, body: request)
   end
 
   def test_write_connection_error
@@ -544,5 +536,36 @@ class WriteApiRetryStrategyTest < MiniTest::Test
 
     assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 3, body: request)
+  end
+
+  def test_abort_on_exception
+    error_body = '{"code":"invalid","message":"unable to parse '\
+                 '\'h2o,location=europe 1\'"}'
+
+    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 400, headers: { 'X-Platform-Error-Code' => 'invalid' }, body: error_body)
+      .to_return(status: 204)
+
+    write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                batch_size: 1, retry_interval: 500, max_retries: 1,
+                                                max_retry_delay: 5_000, exponential_base: 1,
+                                                batch_abort_on_exception: true)
+
+    write_api = @client.create_write_api(write_options: write_options)
+
+    error = assert_raises InfluxDB2::InfluxError do
+      write_api.write(data: 'h2o,location=europe 1')
+      write_api.write(data: 'h2o,location=europe level=2.0 1')
+
+      sleep(2)
+    end
+
+    assert_equal("unable to parse 'h2o,location=europe 1'", error.message)
+
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: 'h2o,location=europe 1')
+
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 0, body: 'h2o,location=europe level=2.0 1')
   end
 end


### PR DESCRIPTION
Related-to #51

## Proposed Changes

- `abort_on_exception`  on `worker` is configurable
- default strategy is **best-effort** - after fail, continue with next batch

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
