### PR TITLE
feat: improved logging message for retries

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,7 @@ Metrics/MethodLength:
 Metrics/ClassLength:
   Max: 300
 Metrics/AbcSize:
-  Max: 40
+  Max: 50
 Metrics/CyclomaticComplexity:
   Max: 15
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.9.0 [unreleased]
 
+### Features
+1. [#55](https://github.com/influxdata/influxdb-client-runy/pull/55): Improved logging message for retries
+
 ## 1.8.0 [2020-10-02]
 
 ### Features

--- a/lib/influxdb2/client/client.rb
+++ b/lib/influxdb2/client/client.rb
@@ -43,6 +43,7 @@ module InfluxDB2
     # @option options [Integer] :read_timeout Number of seconds to wait for one block of data to be read
     # @option options [Integer] :max_redirect_count Maximal number of followed HTTP redirects
     # @option options [bool] :use_ssl Turn on/off SSL for HTTP communication
+    # @option options [Logger] :logger Logger used for logging. Disable logging by set to 'false'.
     # @option options [Hash] :tags Default tags which will be added to each point written by api.
     #   the body line-protocol
     def initialize(url, token, options = nil)
@@ -50,6 +51,7 @@ module InfluxDB2
       @options = options ? options.dup : {}
       @options[:url] = url if url.is_a? String
       @options[:token] = token if token.is_a? String
+      @options[:logger] = @options[:logger].nil? ? DefaultApi.create_logger : @options[:logger]
       @closed = false
 
       at_exit { close! }

--- a/lib/influxdb2/client/client.rb
+++ b/lib/influxdb2/client/client.rb
@@ -43,7 +43,7 @@ module InfluxDB2
     # @option options [Integer] :read_timeout Number of seconds to wait for one block of data to be read
     # @option options [Integer] :max_redirect_count Maximal number of followed HTTP redirects
     # @option options [bool] :use_ssl Turn on/off SSL for HTTP communication
-    # @option options [Logger] :logger Logger used for logging. Disable logging by set to 'false'.
+    # @option options [Logger] :logger Logger used for logging. Disable logging by set to false.
     # @option options [Hash] :tags Default tags which will be added to each point written by api.
     #   the body line-protocol
     def initialize(url, token, options = nil)

--- a/lib/influxdb2/client/default_api.rb
+++ b/lib/influxdb2/client/default_api.rb
@@ -18,6 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+require 'logger'
+
 module InfluxDB2
   # default api
   class DefaultApi
@@ -30,6 +32,29 @@ module InfluxDB2
     def initialize(options:)
       @options = options
       @max_redirect_count = @options[:max_redirect_count] || DEFAULT_REDIRECT_COUNT
+    end
+
+    def log(level, message)
+      return unless @options[:logger]
+
+      log_level = case level
+                  when :debug then
+                    Logger::DEBUG
+                  when :warn then
+                    Logger::WARN
+                  when :error then
+                    Logger::ERROR
+                  when :fatal then
+                    Logger::FATAL
+                  else
+                    Logger::INFO
+                  end
+
+      @options[:logger].add(log_level) { message }
+    end
+
+    def self.create_logger
+      Logger.new(STDOUT)
     end
 
     private

--- a/lib/influxdb2/client/worker.rb
+++ b/lib/influxdb2/client/worker.rb
@@ -116,6 +116,10 @@ module InfluxDB2
                   e.retry_after.to_f
                 end
 
+      message = 'The retriable error occurred during writing of data. '\
+"Reason: '#{e.message}'. Retry in: #{timeout}s."
+
+      @api_client.log(:warn, message)
       sleep timeout
       _write_raw(key, points, attempts + 1, retry_interval * @write_options.exponential_base)
     end

--- a/test/influxdb/default_api_test.rb
+++ b/test/influxdb/default_api_test.rb
@@ -1,0 +1,60 @@
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the 'Software'), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'test_helper'
+require 'influxdb2/client/default_api'
+
+class DefaultApiTest < MiniTest::Test
+  def setup
+    @logger = MockLogger.new
+    @api = InfluxDB2::DefaultApi.new(options: { logger: @logger })
+  end
+
+  def test_level
+    @api.log(:debug, 'debug message')
+    @api.log(:warn, 'warn message')
+    @api.log(:error, 'error message')
+    @api.log(:info, 'info message')
+    @api.log(:others, 'others message')
+
+    assert_equal 5, @logger.messages.count
+
+    assert_equal Logger::DEBUG, @logger.messages[0][0]
+    assert_equal 'debug message', @logger.messages[0][1]
+
+    assert_equal Logger::WARN, @logger.messages[1][0]
+    assert_equal 'warn message', @logger.messages[1][1]
+
+    assert_equal Logger::ERROR, @logger.messages[2][0]
+    assert_equal 'error message', @logger.messages[2][1]
+
+    assert_equal Logger::INFO, @logger.messages[3][0]
+    assert_equal 'info message', @logger.messages[3][1]
+
+    assert_equal Logger::INFO, @logger.messages[4][0]
+    assert_equal 'others message', @logger.messages[4][1]
+  end
+
+  def test_supports_false
+    @api = InfluxDB2::DefaultApi.new(options: { logger: false })
+
+    @api.log(:info, 'without error')
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -37,3 +37,15 @@ require 'minitest/reporters'
 Minitest::Reporters.use!
 
 require 'webmock/minitest'
+
+class MockLogger
+  attr_accessor :messages
+
+  def initialize
+    @messages = []
+  end
+
+  def add(level, &block)
+    @messages << [level, yield(block)]
+  end
+end


### PR DESCRIPTION
## Proposed Changes

The message looks like:

 _The retriable error occurred during writing of data. Reason: 'org 04014de4ed590000 has exceeded limited_write plan limit'. Retry in 5s._

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
