### PR TITLE
fix: query results has precision with nanosecond

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## 1.10.0 [unreleased]
 
 ### Features
- 1. [#59](https://github.com/influxdata/influxdb-client-ruby/pull/59): CSV parser is able to parse export from UI
+1. [#59](https://github.com/influxdata/influxdb-client-ruby/pull/59): CSV parser is able to parse export from UI
+ 
+### Bug Fixes
+1. [#61](https://github.com/influxdata/influxdb-client-ruby/pull/61): Query results has precision with nanosecond, e.g. '1970-01-01T00:00:00.000123456+00:00'
 
 ## 1.9.0 [2020-10-30]
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ The data could be written as:
 
 1. `String` that is formatted as a InfluxDB's line protocol
 1. `Hash` with keys: name, tags, fields and time
-1. [Data Point](https://github.com/influxdata/influxdb-client-ruby/blob/master/lib/influxdb/client/point.rb#L28) structure
+1. [Data Point](https://github.com/influxdata/influxdb-client-ruby/blob/master/lib/influxdb2/client/point.rb#L28) structure
 1. `Array` of above items
 
 ```ruby
@@ -274,7 +274,7 @@ Server availability can be checked using the `client.health` method. That is equ
 
 ### InfluxDB 1.8 API compatibility
 
-[InfluxDB 1.8.0 introduced forward compatibility APIs](https://docs.influxdata.com/influxdb/latest/tools/api/#influxdb-2-0-api-compatibility-endpoints) for InfluxDB 2.0. This allow you to easily move from InfluxDB 1.x to InfluxDB 2.0 Cloud or open source.
+[InfluxDB 1.8.0 introduced forward compatibility APIs](https://docs.influxdata.com/influxdb/v1.8/tools/api/#influxdb-2-0-api-compatibility-endpoints) for InfluxDB 2.0. This allow you to easily move from InfluxDB 1.x to InfluxDB 2.0 Cloud or open source.
 
 The following forward compatible APIs are available:
 

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -244,7 +244,7 @@ module InfluxDB2
       when 'base64Binary'
         Base64.decode64(str_val)
       when 'dateTime:RFC3339', 'dateTime:RFC3339Nano'
-        Time.parse(str_val).to_datetime.rfc3339
+        Time.parse(str_val).to_datetime.rfc3339(9)
       else
         str_val
       end

--- a/test/influxdb/query_api_test.rb
+++ b/test/influxdb/query_api_test.rb
@@ -67,7 +67,7 @@ class QueryApiTest < MiniTest::Test
 
     record1 = result[0].records[0]
 
-    assert_equal Time.parse('1970-01-01T00:00:10Z').to_datetime.rfc3339, record1.time
+    assert_equal Time.parse('1970-01-01T00:00:10Z').to_datetime.rfc3339(9), record1.time
     assert_equal 'mem', record1.measurement
     assert_equal 10, record1.value
     assert_equal 'free', record1.field


### PR DESCRIPTION
Closes #60

## Proposed Changes

The query parser uses nanosecond precision for dates. - e.g. `1970-01-01T00:00:00.000123456+00:00`

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
