### PR TITLE
Implement assert_metric test helpers

### DIFF
--- a/lib/influxdb2/client/client.rb
+++ b/lib/influxdb2/client/client.rb
@@ -24,7 +24,7 @@ module InfluxDB2
   # in https://github.com/influxdata/influxdb/blob/master/http/swagger.yml.
   class Client
     # @return [ Hash ] options The configuration options.
-    attr_reader :options
+    attr_reader :options, :env
 
     # Instantiate a new InfluxDB client.
     #
@@ -52,6 +52,7 @@ module InfluxDB2
       @options[:url] = url if url.is_a? String
       @options[:token] = token if token.is_a? String
       @options[:logger] = @options[:logger].nil? ? DefaultApi.create_logger : @options[:logger]
+      @env = @options[:env] || Environment.current
       @closed = false
 
       at_exit { close! }
@@ -61,7 +62,7 @@ module InfluxDB2
     #
     # @return [WriteApi] New instance of WriteApi.
     def create_write_api(write_options: InfluxDB2::SYNCHRONOUS, point_settings: InfluxDB2::DEFAULT_POINT_SETTINGS)
-      write_api = WriteApi.new(options: @options, write_options: write_options, point_settings: point_settings)
+      write_api = env.default_write_api.new(options: @options, write_options: write_options, point_settings: point_settings)
       @auto_closeable.push(write_api)
       write_api
     end

--- a/lib/influxdb2/client/helpers/assert_metrics.rb
+++ b/lib/influxdb2/client/helpers/assert_metrics.rb
@@ -18,15 +18,25 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-require 'influxdb2/client/default_api'
-require 'influxdb2/client/version'
-require 'influxdb2/client/client'
-require 'influxdb2/client/influx_error'
-require 'influxdb2/client/write_api'
-require 'influxdb2/client/test_write_api'
-require 'influxdb2/client/query_api'
-require 'influxdb2/client/delete_api'
-require 'influxdb2/client/health_api'
-require 'influxdb2/client/point'
-require 'influxdb2/client/flux_table'
-require 'influxdb2/client/environment'
+module InfluxDB2
+  module AssertMetrics
+    def assert_metric(data = {})
+      metrics = if block_given?
+        existing_metrics = InfluxDB2::TestWriteApi.metrics.dup
+        yield
+        InfluxDB2::TestWriteApi.metrics - existing_metrics
+      else
+        InfluxDB2::TestWriteApi.metrics
+      end
+
+      assert_includes(
+        metrics,
+        data
+      )
+    end
+
+    def before_setup
+      InfluxDB2::TestWriteApi.metrics.clear
+    end
+  end
+end

--- a/lib/influxdb2/client/helpers/minitest_helper.rb
+++ b/lib/influxdb2/client/helpers/minitest_helper.rb
@@ -18,15 +18,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
-require 'influxdb2/client/default_api'
-require 'influxdb2/client/version'
-require 'influxdb2/client/client'
-require 'influxdb2/client/influx_error'
-require 'influxdb2/client/write_api'
-require 'influxdb2/client/test_write_api'
-require 'influxdb2/client/query_api'
-require 'influxdb2/client/delete_api'
-require 'influxdb2/client/health_api'
-require 'influxdb2/client/point'
-require 'influxdb2/client/flux_table'
-require 'influxdb2/client/environment'
+require_relative 'assert_metrics'
+
+class Minitest::Test
+  include InfluxDB2::AssertMetrics
+end

--- a/lib/influxdb2/client/test_write_api.rb
+++ b/lib/influxdb2/client/test_write_api.rb
@@ -1,0 +1,92 @@
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+module InfluxDB2
+  class TestWriteApi < WriteApi
+    @metrics = []
+
+    def self.metrics
+      @metrics ||= []
+    end
+
+    def self.metrics=(value)
+      @metrics = value
+    end
+
+    # Write test data into specified Bucket.
+    #
+    # @example write(data:
+    #   [
+    #     {
+    #       name: 'cpu',
+    #       tags: { host: 'server_nl', region: 'us' },
+    #       fields: {internal: 5, external: 6},
+    #       time: 1422568543702900257
+    #     },
+    #     {name: 'gpu', fields: {value: 0.9999}}
+    #   ],
+    #   precision: InfluxDB2::WritePrecision::NANOSECOND,
+    #   bucket: 'my-bucket',
+    #   org: 'my-org'
+    # )
+    #
+    # @example write(data: 'h2o,location=west value=33i 15')
+    #
+    # @example point = InfluxDB2::Point.new(name: 'h2o')
+    #   .add_tag('location', 'europe')
+    #   .add_field('level', 2)
+    #
+    # hash = { name: 'h2o', tags: { host: 'aws', region: 'us' }, fields: { level: 5, saturation: '99%' }, time: 123 }
+    #
+    # write(data: ['h2o,location=west value=33i 15', point, hash])
+    #
+    # @param [Object] data DataPoints to write into InfluxDB. The data could be represent by [Hash], [Point], [String]
+    #   or by collection of these types
+    # @param [WritePrecision] precision The precision for the unix timestamps within the body line-protocol
+    # @param [String] bucket specifies the destination bucket for writes
+    # @param [String] org specifies the destination organization for writes
+    def write(data:, precision: nil, bucket: nil, org: nil)
+      precision_param = precision || @options[:precision]
+      bucket_param = bucket || @options[:bucket]
+      org_param = org || @options[:org]
+      _check('precision', precision_param)
+      _check('bucket', bucket_param)
+      _check('org', org_param)
+
+      _add_default_tags(data)
+
+      return nil if data.nil?
+
+      self.class.metrics << { data: data, precision: precision_param, bucket: bucket_param, org: org_param }
+    end
+
+    # @return [ true ] Always true.
+    def close!
+      true
+    end
+
+    # @param [String] payload data as String
+    # @param [WritePrecision] precision The precision for the unix timestamps within the body line-protocol
+    # @param [String] bucket specifies the destination bucket for writes
+    # @param [String] org specifies the destination organization for writes
+    def write_raw(payload, precision: nil, bucket: nil, org: nil)
+    end
+  end
+end

--- a/test/influxdb/assert_metric_test.rb
+++ b/test/influxdb/assert_metric_test.rb
@@ -1,0 +1,108 @@
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'test_helper'
+require 'influxdb2/client/helpers/minitest_helper'
+
+class AssertMetricTest < Minitest::Test
+  def test_assert_metric_passes
+    build_test_write_api.write(data: 'h2o,location=west value=33i 15')
+
+    assert_metric(
+      data: 'h2o,location=west value=33i 15',
+      precision: InfluxDB2::WritePrecision::NANOSECOND,
+      bucket: 'my-bucket',
+      org: 'my-org',
+    )
+  end
+
+  def test_assert_metric_with_block_passes
+    assert_metric(
+      data: 'h2o,location=west value=33i 15',
+      precision: InfluxDB2::WritePrecision::NANOSECOND,
+      bucket: 'my-bucket',
+      org: 'my-org',
+    ) do
+      build_test_write_api.write(data: 'h2o,location=west value=33i 15')
+    end
+  end
+
+  def test_assert_metric_with_block_fails
+    build_test_write_api.write(data: 'h2o,location=west value=33i 15')
+
+    assert_raises(Minitest::Assertion) do
+      assert_metric(
+        data: 'h2o,location=west value=33i 15',
+        precision: InfluxDB2::WritePrecision::NANOSECOND,
+        bucket: 'my-bucket',
+        org: 'my-org',
+      ) do
+        # no-op
+      end
+    end
+  end
+
+  def test_assert_metric_fails
+    assert_raises(Minitest::Assertion) do
+      assert_metric(
+        data: 'h2o,location=west value=33i 15',
+        precision: InfluxDB2::WritePrecision::NANOSECOND,
+        bucket: 'my-bucket',
+        org: 'my-org',
+      )
+    end
+  end
+
+  def test_assert_metric_with_hash_passes
+    build_test_write_api.write(data: {
+        name: 'h2o',
+        tags: { region: 'us', host: 'aws' },
+        fields: { level: 5, saturation: '99%' }, 
+        time: 123 
+      },
+    )
+
+    assert_metric(
+      data: {
+        name: 'h2o',
+        tags: { region: 'us', host: 'aws' },
+        fields: { level: 5, saturation: '99%' }, 
+        time: 123 
+      },
+      precision: InfluxDB2::WritePrecision::NANOSECOND,
+      bucket: 'my-bucket',
+      org: 'my-org',
+    )
+  end
+
+  private
+
+  def build_test_write_api(bucket: 'my-bucket', org: 'my-org', precision: InfluxDB2::WritePrecision::NANOSECOND)
+    env = InfluxDB2::Environment.new('INFLUXDB_ENV' => 'test')
+    client = InfluxDB2::Client.new(
+      'http://localhost:8086',
+      'my-token',
+      bucket: bucket,
+      org: org,
+      env: env,
+      precision: precision
+    ).create_write_api
+  end
+end


### PR DESCRIPTION
## Proposed Changes

We're in the process of updating [influxdb-rails](https://github.com/influxdata/influxdb-rails) to support the InfluxDB2 client. Currently we built our own test helpers as we don't want to test the internals of the client library e.g. with Webmock. However, I think this is useful for anyone using this library so I'm proposing to include this here rather than in influxb-rails.

This PR implements an `assert_metric` test helper which can be used like this

```ruby
def test_assert_metric_passes
  write_api.write(data: 'h2o,location=west value=33i 15')

  assert_metric(
    data: 'h2o,location=west value=33i 15',
    precision: InfluxDB2::WritePrecision::NANOSECOND,
    bucket: 'my-bucket',
    org: 'my-org',
  )
end

def test_assert_metric_passes_with_block
  assert_metric(
    data: 'h2o,location=west value=33i 15',
    precision: InfluxDB2::WritePrecision::NANOSECOND,
    bucket: 'my-bucket',
    org: 'my-org',
  ) do
    write_api.write(data: 'h2o,location=west value=33i 15')
  end
end
```

Similar test helpers are for instance implement in [ActiveJob](https://api.rubyonrails.org/v5.2.3/classes/ActiveJob/TestHelper.html) and [ActionMailer](https://api.rubyonrails.org/v5.1.7/classes/ActionMailer/TestHelper.html).



### ToDo

There are still a few things todo but before I continue I wanted to test the water first if this has potential to get accepted.

- [ ] Add documentation
- [ ] Implement partial matching for hashes (`hash_including`)
- [ ] Implement `write_raw`

## Checklist

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] `rake test` completes successfully
- [ ] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
