### PR TITLE
feat: add possibility to specify the certification verification behaviour

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 1.12.0 [unreleased]
 
+### Features
+1. [#71](https://github.com/influxdata/influxdb-client-ruby/pull/71): Added possibility to specify the certification verification behaviour
+
 ## 1.11.0 [2021-01-29]
 
 ### CI

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ client = InfluxDB2::Client.new('https://localhost:8086', 'my-token')
 | read_timeout | Number of seconds to wait for one block of data to be read | Integer | 10 |
 | max_redirect_count | Maximal number of followed HTTP redirects | Integer | 10 |
 | use_ssl | Turn on/off SSL for HTTP communication | bool | true |
+| verify_mode | Sets the flags for the certification verification at beginning of SSL/TLS session. | `OpenSSL::SSL::VERIFY_NONE` or `OpenSSL::SSL::VERIFY_PEER` | none |
 
 ```ruby
 client = InfluxDB2::Client.new('https://localhost:8086', 'my-token',

--- a/lib/influxdb2/client/client.rb
+++ b/lib/influxdb2/client/client.rb
@@ -43,6 +43,9 @@ module InfluxDB2
     # @option options [Integer] :read_timeout Number of seconds to wait for one block of data to be read
     # @option options [Integer] :max_redirect_count Maximal number of followed HTTP redirects
     # @option options [bool] :use_ssl Turn on/off SSL for HTTP communication
+    # @option options [Integer] :verify_mode Sets the flags for the certification verification
+    #   at beginning of SSL/TLS session. Could be one of `OpenSSL::SSL::VERIFY_NONE` or `OpenSSL::SSL::VERIFY_PEER`.
+    #   For more info see - https://docs.ruby-lang.org/en/3.0.0/Net/HTTP.html#verify_mode.
     # @option options [Logger] :logger Logger used for logging. Disable logging by set to false.
     # @option options [Hash] :tags Default tags which will be added to each point written by api.
     #   the body line-protocol

--- a/test/influxdb/default_api_test.rb
+++ b/test/influxdb/default_api_test.rb
@@ -57,4 +57,33 @@ class DefaultApiTest < MiniTest::Test
 
     @api.log(:info, 'without error')
   end
+
+  def test_default_verify_mode
+    http_client = @api.send(:_prepare_http_client, URI.parse('https://localhost:8086'))
+
+    refute_nil http_client
+    assert_nil http_client.verify_mode
+
+    http_client.finish if http_client.started?
+  end
+
+  def test_default_verify_mode_none
+    @api = InfluxDB2::DefaultApi.new(options: { logger: @logger, verify_mode: OpenSSL::SSL::VERIFY_NONE })
+    http_client = @api.send(:_prepare_http_client, URI.parse('https://localhost:8086'))
+
+    refute_nil http_client
+    assert_equal OpenSSL::SSL::VERIFY_NONE, http_client.verify_mode
+
+    http_client.finish if http_client.started?
+  end
+
+  def test_default_verify_mode_peer
+    @api = InfluxDB2::DefaultApi.new(options: { logger: @logger, verify_mode: OpenSSL::SSL::VERIFY_PEER })
+    http_client = @api.send(:_prepare_http_client, URI.parse('https://localhost:8086'))
+
+    refute_nil http_client
+    assert_equal OpenSSL::SSL::VERIFY_PEER, http_client.verify_mode
+
+    http_client.finish if http_client.started?
+  end
 end


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb-plugin-fluent/issues/22

## Proposed Changes

Added the new option to customise certification verification behaviour:

| Option | Description | Type | Default |
|---|---|---|---|
| verify_mode | Sets the flags for the certification verification at beginning of SSL/TLS session. | `OpenSSL::SSL::VERIFY_NONE` or `OpenSSL::SSL::VERIFY_PEER` | none |

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
