### PR TITLE
fix: avoid uses sources from parent path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.13.0 [unreleased]
 
+## 1.12.1 [2021-03-05]
+
+### Bug Fixes
+1. [#74](https://github.com/influxdata/influxdb-client-ruby/pull/74): Avoid uses sources from parent path
+
 ## 1.12.0 [2021-03-05]
 
 ### Features

--- a/apis/LICENSE
+++ b/apis/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Influxdata, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/apis/influxdb-client-apis.gemspec
+++ b/apis/influxdb-client-apis.gemspec
@@ -39,8 +39,7 @@ Gem::Specification.new do |spec|
   spec.metadata['changelog_uri'] = 'https://raw.githubusercontent.com/influxdata/influxdb-client-ruby/master/CHANGELOG.md'
 
   spec.files = Dir.glob('lib/**/*')
-  # spec.files += %w[influxdb-client-apis.gemspec ../LICENSE ../README.md ../CHANGELOG.md Rakefile]
-  spec.files += %w[influxdb-client-apis.gemspec Rakefile]
+  spec.files += %w[influxdb-client-apis.gemspec LICENSE Rakefile]
   spec.test_files = Dir.glob('test/**/*')
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.2.0'

--- a/lib/influxdb2/client/version.rb
+++ b/lib/influxdb2/client/version.rb
@@ -19,5 +19,5 @@
 # THE SOFTWARE.
 
 module InfluxDB2
-  VERSION = '1.13.0'.freeze
+  VERSION = '1.12.1'.freeze
 end


### PR DESCRIPTION
## Proposed Changes

Avoid uses sources from parent path:

```
Gem::Package::PathError: installing into parent path /home/ubuntu/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/CHANGELOG.md of /home/ubuntu/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/gems/influxdb-client-apis-1.12.0 is not allowed
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
