### PR TITLE
feat: `Authorization` header is not forwarded when redirect leads to a different domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
-## 1.18.0 [unreleased]
+## 2.0.0 [unreleased]
 
+### Breaking Changes
+Due to a security reason `Authorization` header is not forwarded when redirect leads to a different domain.
+To overcome this limitation you have to set the client property `redirect_forward_authorization` to `true`.
+
+### Features
+1. [#89](https://github.com/influxdata/influxdb-client-ruby/pull/89): `Authorization` header is not forwarded when redirect leads to a different domain
+
+### Bug Fixes
+1. [#89](https://github.com/influxdata/influxdb-client-ruby/pull/89): Correct redirect location
+ 
 ## 1.17.0 [2021-08-20]
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ This repository contains the reference Ruby client for the InfluxDB 2.0.
     - [Management API](#management-api)
 - [Advanced Usage](#advanced-usage)
     - [Default Tags](#default-tags)
+    - [Proxy configuration](#proxy-configuration)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -93,6 +94,7 @@ client = InfluxDB2::Client.new('https://localhost:8086', 'my-token')
 | write_timeout | Number of seconds to wait for one block of data to be written | Integer | 10 |
 | read_timeout | Number of seconds to wait for one block of data to be read | Integer | 10 |
 | max_redirect_count | Maximal number of followed HTTP redirects | Integer | 10 |
+| redirect_forward_authorization | Pass Authorization header to different domain during HTTP redirect. | bool | false |
 | use_ssl | Turn on/off SSL for HTTP communication | bool | true |
 | verify_mode | Sets the flags for the certification verification at beginning of SSL/TLS session. | `OpenSSL::SSL::VERIFY_NONE` or `OpenSSL::SSL::VERIFY_PEER` | none |
 
@@ -399,6 +401,20 @@ client.close!
 ### Check the server status 
 
 Server availability can be checked using the `client.health` method. That is equivalent of the [influx ping](https://v2.docs.influxdata.com/v2.0/reference/cli/influx/ping/).
+
+### Proxy configuration
+
+You can configure the client to tunnel requests through an HTTP proxy. To configure the proxy use a `http_proxy` environment variable. 
+
+```ruby
+ENV['HTTP_PROXY'] = 'http://my-user:my-password@my-proxy:8099'
+```
+
+Client automatically follows HTTP redirects. The default redirect policy is to follow up to 10 consecutive requests.
+You can configure redirect counts by the client property: `max_redirect_count`. 
+
+Due to a security reason `Authorization` header is not forwarded when redirect leads to a different domain. 
+To overcome this limitation you have to set the client property `redirect_forward_authorization` to `true`.
 
 ### InfluxDB 1.8 API compatibility
 

--- a/lib/influxdb2/client/client.rb
+++ b/lib/influxdb2/client/client.rb
@@ -42,6 +42,8 @@ module InfluxDB2
     # @option options [Integer] :write_timeout Number of seconds to wait for one block of data to be written
     # @option options [Integer] :read_timeout Number of seconds to wait for one block of data to be read
     # @option options [Integer] :max_redirect_count Maximal number of followed HTTP redirects
+    # @option options [bool] :redirect_forward_authorization Pass Authorization header to different domain
+    #   during HTTP redirect.
     # @option options [bool] :use_ssl Turn on/off SSL for HTTP communication
     # @option options [Integer] :verify_mode Sets the flags for the certification verification
     #   at beginning of SSL/TLS session. Could be one of `OpenSSL::SSL::VERIFY_NONE` or `OpenSSL::SSL::VERIFY_PEER`.

--- a/lib/influxdb2/client/version.rb
+++ b/lib/influxdb2/client/version.rb
@@ -19,5 +19,5 @@
 # THE SOFTWARE.
 
 module InfluxDB2
-  VERSION = '1.18.0'.freeze
+  VERSION = '2.0.0'.freeze
 end

--- a/test/influxdb/redirect_test.rb
+++ b/test/influxdb/redirect_test.rb
@@ -1,0 +1,145 @@
+# The MIT License
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'test_helper'
+
+class WriteApiTest < MiniTest::Test
+  def setup
+    WebMock.disable_net_connect!
+  end
+
+  def test_redirect_same
+    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 307, headers:
+        { 'location' => 'http://localhost:8086' })
+      .then.to_return(status: 204)
+    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 204)
+
+    client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
+                                   bucket: 'my-bucket',
+                                   org: 'my-org',
+                                   precision: InfluxDB2::WritePrecision::NANOSECOND,
+                                   use_ssl: false)
+
+    client.create_write_api.write(data: 'h2o,location=west value=33i 15')
+
+    headers = {
+      'Authorization' => 'Token my-token',
+      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}",
+      'Content-Type' => 'text/plain'
+    }
+
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: 'h2o,location=west value=33i 15', headers: headers)
+  end
+
+  def test_redirect_301
+    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 301, headers:
+        { 'location' => 'http://localhost:9090/' })
+      .then.to_return(status: 204)
+    stub_request(:any, 'http://localhost:9090/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 204)
+
+    client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
+                                   bucket: 'my-bucket',
+                                   org: 'my-org',
+                                   precision: InfluxDB2::WritePrecision::NANOSECOND,
+                                   use_ssl: false)
+
+    client.create_write_api.write(data: 'h2o,location=west value=33i 15')
+
+    headers = {
+      'Authorization' => 'Token my-token',
+      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}",
+      'Content-Type' => 'text/plain'
+    }
+
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: 'h2o,location=west value=33i 15', headers: headers)
+
+    assert_not_requested(:post, 'http://localhost:9090/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                         times: 1, body: 'h2o,location=west value=33i 15', headers: headers)
+
+    assert_requested(:post, 'http://localhost:9090/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: 'h2o,location=west value=33i 15')
+  end
+
+  def test_redirect_301_allow
+    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 301, headers:
+        { 'location' => 'http://localhost:9090/' })
+      .then.to_return(status: 204)
+    stub_request(:any, 'http://localhost:9090/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 204)
+
+    client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
+                                   bucket: 'my-bucket',
+                                   org: 'my-org',
+                                   precision: InfluxDB2::WritePrecision::NANOSECOND,
+                                   use_ssl: false,
+                                   redirect_forward_authorization: true)
+
+    client.create_write_api.write(data: 'h2o,location=west value=33i 15')
+
+    headers = {
+      'Authorization' => 'Token my-token',
+      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}",
+      'Content-Type' => 'text/plain'
+    }
+
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: 'h2o,location=west value=33i 15', headers: headers)
+
+    assert_requested(:post, 'http://localhost:9090/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: 'h2o,location=west value=33i 15', headers: headers)
+  end
+
+  def test_redirect_different_path
+    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 301, headers:
+        { 'location' => 'http://localhost:8086/influxdb/' })
+      .then.to_return(status: 204)
+    stub_request(:any, 'http://localhost:8086/influxdb/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 204)
+
+    client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
+                                   bucket: 'my-bucket',
+                                   org: 'my-org',
+                                   precision: InfluxDB2::WritePrecision::NANOSECOND,
+                                   use_ssl: false,
+                                   redirect_forward_authorization: true)
+
+    client.create_write_api.write(data: 'h2o,location=west value=33i 15')
+
+    headers = {
+      'Authorization' => 'Token my-token',
+      'User-Agent' => "influxdb-client-ruby/#{InfluxDB2::VERSION}",
+      'Content-Type' => 'text/plain'
+    }
+
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: 'h2o,location=west value=33i 15', headers: headers)
+
+    assert_requested(:post, 'http://localhost:8086/influxdb/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 1, body: 'h2o,location=west value=33i 15', headers: headers)
+  end
+end

--- a/test/influxdb/write_api_test.rb
+++ b/test/influxdb/write_api_test.rb
@@ -201,7 +201,7 @@ class WriteApiTest < MiniTest::Test
   def test_follow_redirect
     stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
       .to_return(status: 307, headers:
-          { 'location' => 'http://localhost:9090/api/v2/write?bucket=my-bucket&org=my-org&precision=ns' })
+          { 'location' => 'http://localhost:9090/' })
       .then.to_return(status: 204)
     stub_request(:any, 'http://localhost:9090/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
       .to_return(status: 204)
@@ -223,7 +223,7 @@ class WriteApiTest < MiniTest::Test
   def test_follow_redirect_max
     stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
       .to_return(status: 307, headers:
-          { 'location' => 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns' })
+          { 'location' => 'http://localhost:8086/' })
 
     client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
                                    bucket: 'my-bucket',


### PR DESCRIPTION
## Proposed Changes

1. `Authorization` header is not forwarded when redirect leads to a different domain
2. Fix redirect location
3. Add documentation how to configure proxy

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
