### PR TITLE
fix: parse 503 plain text error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.0.0 [unreleased]
 
+### Bug Fixes
+1. [#90](https://github.com/influxdata/influxdb-client-ruby/pull/90): Fix parse text plain 503 error response  
+
 ### Breaking Changes
 Due to a security reason `Authorization` header is not forwarded when redirect leads to a different domain.
 To overcome this limitation you have to set the client property `redirect_forward_authorization` to `true`.

--- a/lib/influxdb2/client/influx_error.rb
+++ b/lib/influxdb2/client/influx_error.rb
@@ -31,17 +31,13 @@ module InfluxDB2
     end
 
     def self.from_response(response)
-      begin
       json = JSON.parse(response.body)
       obj = new(message: json['message'] || '', code: response.code, reference: json['code'] || '',
                 retry_after: response['Retry-After'] || '')
       obj
-      rescue JSON::ParserError
-        new(message: response.body || '',
-                  code:response.code,
-                  reference: '',
-                  retry_after: response['Retry-After'] || '')
-      end
+    rescue JSON::ParserError
+      new(message: response.body || '', code: response.code, reference: '',
+          retry_after: response['Retry-After'] || '')
     end
 
     def self.from_message(message)

--- a/lib/influxdb2/client/influx_error.rb
+++ b/lib/influxdb2/client/influx_error.rb
@@ -31,10 +31,17 @@ module InfluxDB2
     end
 
     def self.from_response(response)
+      begin
       json = JSON.parse(response.body)
       obj = new(message: json['message'] || '', code: response.code, reference: json['code'] || '',
                 retry_after: response['Retry-After'] || '')
       obj
+      rescue JSON::ParserError
+        new(message: response.body || '',
+                  code:response.code,
+                  reference: '',
+                  retry_after: response['Retry-After'] || '')
+      end
     end
 
     def self.from_message(message)

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -618,34 +618,11 @@ class WriteApiRetryStrategyTest < MiniTest::Test
     assert_lte backoff, 2_000
   end
 
-  def test_write_error_plain
-    error_body = 'Service Unavailable'
-    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
-      .to_return(status: 503, headers: { 'content-type' => 'text/plain' },
-                 body: error_body)
-
-    client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
-                                   bucket: 'my-bucket',
-                                   org: 'my-org',
-                                   precision: InfluxDB2::WritePrecision::NANOSECOND,
-                                   use_ssl: false)
-
-    error = assert_raises InfluxDB2::InfluxError do
-      write_api = client.create_write_api
-      write_api.write(data: 'h2o,location=west value=33i 15')
-    end
-
-    assert_equal '503', error.code
-    assert_equal "Service Unavailable", error.message
-  end
-
   def test_write_error_plain_retry
     error_body = 'Service Unavailable'
-
     stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
       .to_return(status: 503, headers: { 'content-type' => 'text/plain', 'Retry-After' => '2' }, body: error_body)
-      .to_return(status: 503, headers: { 'content-type' => 'text/plain' }, body: error_body)
-      .to_return(status: 204)
+      .to_return(status: 503, headers: { 'content-type' => 'text/plain' }, body: error_body).to_return(status: 204)
 
     client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
                                    bucket: 'my-bucket',
@@ -661,10 +638,7 @@ class WriteApiRetryStrategyTest < MiniTest::Test
     write_api.write(data: request)
 
     sleep(10)
-
     assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
                      times: 3, body: request)
-
   end
-
 end

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -210,11 +210,6 @@ class WriteApiBatchingTest < MiniTest::Test
     @write_client.write(data: ['h2o_feet,location=coyote_creek water_level=1.0 1',
                                'h2o_feet,location=coyote_creek water_level=2.0 2'])
 
-    sleep(0.05)
-
-    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
-                     times: 0, body: request)
-
     sleep(2)
 
     assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',

--- a/test/influxdb/write_api_batching_test.rb
+++ b/test/influxdb/write_api_batching_test.rb
@@ -617,4 +617,54 @@ class WriteApiRetryStrategyTest < MiniTest::Test
     assert_gte backoff, 1_600
     assert_lte backoff, 2_000
   end
+
+  def test_write_error_plain
+    error_body = 'Service Unavailable'
+    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 503, headers: { 'content-type' => 'text/plain' },
+                 body: error_body)
+
+    client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
+                                   bucket: 'my-bucket',
+                                   org: 'my-org',
+                                   precision: InfluxDB2::WritePrecision::NANOSECOND,
+                                   use_ssl: false)
+
+    error = assert_raises InfluxDB2::InfluxError do
+      write_api = client.create_write_api
+      write_api.write(data: 'h2o,location=west value=33i 15')
+    end
+
+    assert_equal '503', error.code
+    assert_equal "Service Unavailable", error.message
+  end
+
+  def test_write_error_plain_retry
+    error_body = 'Service Unavailable'
+
+    stub_request(:any, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns')
+      .to_return(status: 503, headers: { 'content-type' => 'text/plain', 'Retry-After' => '2' }, body: error_body)
+      .to_return(status: 503, headers: { 'content-type' => 'text/plain' }, body: error_body)
+      .to_return(status: 204)
+
+    client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
+                                   bucket: 'my-bucket',
+                                   org: 'my-org',
+                                   precision: InfluxDB2::WritePrecision::NANOSECOND,
+                                   use_ssl: false)
+
+    @write_options = InfluxDB2::WriteOptions.new(write_type: InfluxDB2::WriteType::BATCHING,
+                                                 batch_size: 1, flush_interval: 1_000, retry_interval: 1_000)
+
+    write_api = client.create_write_api(write_options: @write_options)
+    request = 'h2o,location=west value=33i 15'
+    write_api.write(data: request)
+
+    sleep(10)
+
+    assert_requested(:post, 'http://localhost:8086/api/v2/write?bucket=my-bucket&org=my-org&precision=ns',
+                     times: 3, body: request)
+
+  end
+
 end


### PR DESCRIPTION
## Proposed Changes

This PR fixes handling of plain-text http errors. 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
