### PR TITLE
chore(ci): switch to next-gen CircleCI's convenience images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,9 +45,9 @@ commands:
       - restore_cache:
           name: Restoring Gem Cache
           keys:
-            - &cache-key gem-cache-{{ checksum "<< parameters.path >>/<< parameters.gemspec-file >>" }}-<< parameters.ruby-image >>
-            - gem-cache-{{ checksum "<< parameters.path >>/<< parameters.gemspec-file >>" }}
-            - gem-cache-
+            - &cache-key gem-cache-v2-{{ checksum "<< parameters.path >>/<< parameters.gemspec-file >>" }}-<< parameters.ruby-image >>
+            - gem-cache-v2-{{ checksum "<< parameters.path >>/<< parameters.gemspec-file >>" }}
+            - gem-cache-v2-
       - run:
           name: Install dependencies
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,10 +238,10 @@ workflows:
             - client-r2.4
       - tests-ruby:
           name: client-jruby
-          ruby-image: "jruby:9.2.19.0"
+          ruby-image: "jruby:9.2.17.0"
       - tests-ruby:
           name: APIs-jruby
-          ruby-image: "jruby:9.2.19.0"
+          ruby-image: "jruby:9.2.17.0"
           gemspec-file: influxdb-client-apis.gemspec
           path: ./apis
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
     parameters:
       ruby-image:
         type: string
-        default: &default-ruby-image "circleci/ruby:2.6-stretch"
+        default: &default-ruby-image "cimg/ruby:2.6"
       influxdb-image:
         type: string
         default: &default-influxdb-image "influxdb:latest"
@@ -180,20 +180,20 @@ workflows:
     jobs:
       - tests-ruby:
           name: client-r3.0
-          ruby-image: "circleci/ruby:3.0-buster"
+          ruby-image: "cimg/ruby:3.0"
       - tests-ruby:
           name: APIs-r3.0
-          ruby-image: "circleci/ruby:3.0-buster"
+          ruby-image: "cimg/ruby:3.0"
           gemspec-file: influxdb-client-apis.gemspec
           path: ./apis
           requires:
             - client-r3.0
       - tests-ruby:
           name: client-r2.7
-          ruby-image: "circleci/ruby:2.7-buster"
+          ruby-image: "cimg/ruby:2.7"
       - tests-ruby:
           name: APIs-r2.7
-          ruby-image: "circleci/ruby:2.7-buster"
+          ruby-image: "cimg/ruby:2.7"
           gemspec-file: influxdb-client-apis.gemspec
           path: ./apis
           requires:
@@ -218,30 +218,30 @@ workflows:
             - client-r2.6-nightly
       - tests-ruby:
           name: client-r2.5
-          ruby-image: "circleci/ruby:2.5-stretch"
+          ruby-image: "cimg/ruby:2.5"
       - tests-ruby:
           name: APIs-r2.5
-          ruby-image: "circleci/ruby:2.5-stretch"
+          ruby-image: "cimg/ruby:2.5"
           gemspec-file: influxdb-client-apis.gemspec
           path: ./apis
           requires:
             - client-r2.5
       - tests-ruby:
           name: client-r2.4
-          ruby-image: "circleci/ruby:2.4-stretch"
+          ruby-image: "cimg/ruby:2.4"
       - tests-ruby:
           name: APIs-r2.4
-          ruby-image: "circleci/ruby:2.4-stretch"
+          ruby-image: "cimg/ruby:2.4"
           gemspec-file: influxdb-client-apis.gemspec
           path: ./apis
           requires:
             - client-r2.4
       - tests-ruby:
           name: client-jruby
-          ruby-image: "circleci/jruby:9.2.17.0"
+          ruby-image: "jruby:9.2.19.0"
       - tests-ruby:
           name: APIs-jruby
-          ruby-image: "circleci/jruby:9.2.17.0"
+          ruby-image: "jruby:9.2.19.0"
           gemspec-file: influxdb-client-apis.gemspec
           path: ./apis
           requires:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,13 @@
 ## 2.1.0 [unreleased]
 
+### CI
+1. [#91](https://github.com/influxdata/influxdb-client-ruby/pull/91): Switch to next-gen CircleCI's convenience images
+
 ## 2.0.0 [2021-09-13]
 
 ### Bug Fixes
 1. [#90](https://github.com/influxdata/influxdb-client-ruby/pull/90): Fix parse text plain 503 error response  
 1. [#89](https://github.com/influxdata/influxdb-client-ruby/pull/89): Correct redirect location
-
-### CI
-1. [#91](https://github.com/influxdata/influxdb-client-ruby/pull/91): Switch to next-gen CircleCI's convenience images
 
 ### Breaking Changes
 Due to a security reason `Authorization` header is not forwarded when redirect leads to a different domain.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 1. [#90](https://github.com/influxdata/influxdb-client-ruby/pull/90): Fix parse text plain 503 error response  
 1. [#89](https://github.com/influxdata/influxdb-client-ruby/pull/89): Correct redirect location
 
+### CI
+1. [#91](https://github.com/influxdata/influxdb-client-ruby/pull/91): Switch to next-gen CircleCI's convenience images
+
 ### Breaking Changes
 Due to a security reason `Authorization` header is not forwarded when redirect leads to a different domain.
 To overcome this limitation you have to set the client property `redirect_forward_authorization` to `true`.


### PR DESCRIPTION
## Proposed Changes

The current images are deprecated and no longer supported:
- https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034?mkt_tok=NDg1LVpNSC02MjYAAAF_aZ4aQBMMtwIJatxoGz4de_IMPoNZJOUAhbHY2j7KD_4fR38oMpf0qFjUBd15_QNaVKiHbjM5WE0emhPAvcNcagGm1rnILLJptARAtBWPhtQ
- https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
