### PR TITLE
fix(ci): use proper way how to build a gem from other directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
           command: |
             ./bin/generate-sources.sh
             gem build influxdb-client.gemspec
-            gem build apis/influxdb-client-apis.gemspec
+            gem build -C apis influxdb-client-apis.gemspec
       - save_cache:
           name: Saving Cache
           key: *generate-sources-cache-key


### PR DESCRIPTION
## Proposed Changes

Fixed nightly build:

![image](https://user-images.githubusercontent.com/455137/133203617-7fd42436-820a-4199-b47f-4c5f7d64a889.png)

- https://github.com/rubygems/rubygems/pull/2596
- https://github.com/rubygems/rubygems/pull/3983

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed)
