### PR TITLE
fix: add missing PermissionResource types from Cloud definition

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,10 +139,10 @@ jobs:
           keys:
             - &generate-sources-cache-key gs-cache-v1
       - run:
-          name: Install Maven
+          name: Install Maven & Git
           command: |
             sudo apt-get update
-            sudo apt-get install maven --yes
+            sudo apt-get install maven git --yes
       - run:
           name: Checks generating sources from swagger
           command: |

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ vendor
 docs
 /.openapi-generator/
 bin/generated/
+bin/cloud.yml
+bin/oss.yml
+bin/influxdb-clients-apigen/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### Features
 1. [#96](https://github.com/influxdata/influxdb-client-ruby/pull/96): Add support for Parameterized Queries
 
+### Bug Fixes
+1. [#97](https://github.com/influxdata/influxdb-client-ruby/pull/97): Add missing PermissionResources from Cloud API definition
+
 ### Documentation
 1. [#96](https://github.com/influxdata/influxdb-client-ruby/pull/96): Add Parameterized Queries example
 

--- a/apis/lib/influxdb2/apis/generated/models/resource.rb
+++ b/apis/lib/influxdb2/apis/generated/models/resource.rb
@@ -130,7 +130,7 @@ module InfluxDB2::API
     # @return true if the model is valid
     def valid?
       return false if @type.nil?
-      type_validator = EnumAttributeValidator.new('String', ["authorizations", "buckets", "dashboards", "orgs", "sources", "tasks", "telegrafs", "users", "variables", "scrapers", "secrets", "labels", "views", "documents", "notificationRules", "notificationEndpoints", "checks", "dbrp", "notebooks", "annotations", "remotes", "replications"])
+      type_validator = EnumAttributeValidator.new('String', ["authorizations", "buckets", "dashboards", "orgs", "sources", "tasks", "telegrafs", "users", "variables", "scrapers", "secrets", "labels", "views", "documents", "notificationRules", "notificationEndpoints", "checks", "dbrp", "notebooks", "annotations", "remotes", "replications", "flows", "functions"])
       return false unless type_validator.valid?(@type)
       true
     end
@@ -138,7 +138,7 @@ module InfluxDB2::API
     # Custom attribute writer method checking allowed values (enum).
     # @param [Object] type Object to be assigned
     def type=(type)
-      validator = EnumAttributeValidator.new('String', ["authorizations", "buckets", "dashboards", "orgs", "sources", "tasks", "telegrafs", "users", "variables", "scrapers", "secrets", "labels", "views", "documents", "notificationRules", "notificationEndpoints", "checks", "dbrp", "notebooks", "annotations", "remotes", "replications"])
+      validator = EnumAttributeValidator.new('String', ["authorizations", "buckets", "dashboards", "orgs", "sources", "tasks", "telegrafs", "users", "variables", "scrapers", "secrets", "labels", "views", "documents", "notificationRules", "notificationEndpoints", "checks", "dbrp", "notebooks", "annotations", "remotes", "replications", "flows", "functions"])
       unless validator.valid?(type)
         fail ArgumentError, "invalid value for \"type\", must be one of #{validator.allowable_values}."
       end

--- a/bin/generate-sources.sh
+++ b/bin/generate-sources.sh
@@ -15,7 +15,7 @@ rm -rf "${SCRIPT_PATH}"/cloud.yml || true
 rm -rf "${SCRIPT_PATH}"/influxdb-clients-apigen || true
 wget https://raw.githubusercontent.com/influxdata/openapi/master/contracts/oss.yml -O "${SCRIPT_PATH}/oss.yml"
 wget https://raw.githubusercontent.com/influxdata/openapi/master/contracts/cloud.yml -O "${SCRIPT_PATH}/cloud.yml"
-git clone --single-branch --branch permission_type_from_cloud https://github.com/bonitoo-io/influxdb-clients-apigen "${SCRIPT_PATH}/influxdb-clients-apigen"
+git clone --single-branch --branch master https://github.com/bonitoo-io/influxdb-clients-apigen "${SCRIPT_PATH}/influxdb-clients-apigen"
 mvn -f "$SCRIPT_PATH"/influxdb-clients-apigen/openapi-generator/pom.xml compile exec:java -Dexec.mainClass="com.influxdb.AppendCloudDefinitions" -Dexec.args="$SCRIPT_PATH/oss.yml $SCRIPT_PATH/cloud.yml"
 
 # Generate client

--- a/bin/generate-sources.sh
+++ b/bin/generate-sources.sh
@@ -2,12 +2,21 @@
 
 #
 # How to run script from ROOT path:
-#   docker run --rm -it -v "${PWD}":/code -v ~/.m2:/root/.m2 -w /code maven:3.6-slim /code/bin/generate-sources.sh
+#   docker run --rm -it -v "${PWD}":/code -v ~/.m2:/root/.m2 -w /code maven:3-openjdk-8 /code/bin/generate-sources.sh
 #
 
 SCRIPT_PATH="$( cd "$(dirname "$0")" || exit ; pwd -P )"
 
 rm -rf "${SCRIPT_PATH}"/generated
+
+# Download and match OSS and Cloud definition
+rm -rf "${SCRIPT_PATH}"/oss.yml || true
+rm -rf "${SCRIPT_PATH}"/cloud.yml || true
+rm -rf "${SCRIPT_PATH}"/influxdb-clients-apigen || true
+wget https://raw.githubusercontent.com/influxdata/openapi/master/contracts/oss.yml -O "${SCRIPT_PATH}/oss.yml"
+wget https://raw.githubusercontent.com/influxdata/openapi/master/contracts/cloud.yml -O "${SCRIPT_PATH}/cloud.yml"
+git clone --single-branch --branch permission_type_from_cloud https://github.com/bonitoo-io/influxdb-clients-apigen "${SCRIPT_PATH}/influxdb-clients-apigen"
+mvn -f "$SCRIPT_PATH"/influxdb-clients-apigen/openapi-generator/pom.xml compile exec:java -Dexec.mainClass="com.influxdb.AppendCloudDefinitions" -Dexec.args="$SCRIPT_PATH/oss.yml $SCRIPT_PATH/cloud.yml"
 
 # Generate client
 cd "${SCRIPT_PATH}"/ || exit

--- a/bin/generate-sources.sh
+++ b/bin/generate-sources.sh
@@ -9,7 +9,7 @@ SCRIPT_PATH="$( cd "$(dirname "$0")" || exit ; pwd -P )"
 
 rm -rf "${SCRIPT_PATH}"/generated
 
-# Download and match OSS and Cloud definition
+# Download and merge OSS and Cloud definition
 rm -rf "${SCRIPT_PATH}"/oss.yml || true
 rm -rf "${SCRIPT_PATH}"/cloud.yml || true
 rm -rf "${SCRIPT_PATH}"/influxdb-clients-apigen || true

--- a/bin/pom.xml
+++ b/bin/pom.xml
@@ -13,7 +13,7 @@
                 <artifactId>openapi-generator-maven-plugin</artifactId>
                 <version>5.1.1</version>
                 <configuration>
-                    <inputSpec>https://raw.githubusercontent.com/influxdata/openapi/master/contracts/oss.yml</inputSpec>
+                    <inputSpec>./oss.yml</inputSpec>
                     <generatorName>ruby</generatorName>
                     <configOptions>
                       <moduleName>InfluxDB2</moduleName>


### PR DESCRIPTION
## Proposed Changes

Added missing `PermissionResource` types.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
