### PR TITLE
chore(ci): use new codecov uploader for reporting code coverage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,17 @@ commands:
             cd << parameters.path >>
             export MINITEST_REPORTER=JUnitReporter
             bundle exec rake test
+      - run:
+          name: Collecting coverage reports
+          command: |
+            curl -Os https://uploader.codecov.io/latest/linux/codecov
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM
+            curl -Os https://uploader.codecov.io/latest/linux/codecov.SHA256SUM.sig
+            curl -s https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import
+            gpgv codecov.SHA256SUM.sig codecov.SHA256SUM
+            shasum -a 256 -c codecov.SHA256SUM
+            chmod +x ./codecov
+            ./codecov
       - save_cache:
           name: Saving Gem Cache
           key: *cache-key

--- a/apis/influxdb-client-apis.gemspec
+++ b/apis/influxdb-client-apis.gemspec
@@ -48,11 +48,10 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'codecov', '~> 0.1.16'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-reporters', '~> 1.4'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rubocop', '~> 0.66.0'
-  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'simplecov-cobertura', '~> 2.1'
   spec.add_development_dependency 'webmock', '~> 3.7'
 end

--- a/apis/test/test_helper.rb
+++ b/apis/test/test_helper.rb
@@ -24,8 +24,8 @@ SimpleCov.start do
 end
 
 if ENV['CI'] == 'true'
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)

--- a/influxdb-client.gemspec
+++ b/influxdb-client.gemspec
@@ -45,11 +45,10 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_development_dependency 'bundler', '~> 2.0'
-  spec.add_development_dependency 'codecov', '~> 0.1.16'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'minitest-reporters', '~> 1.4'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rubocop', '~> 0.66.0'
-  spec.add_development_dependency 'simplecov', '~> 0.17.1'
+  spec.add_development_dependency 'simplecov-cobertura', '~> 2.1'
   spec.add_development_dependency 'webmock', '~> 3.7'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,8 +25,8 @@ SimpleCov.start do
 end
 
 if ENV['CI'] == 'true'
-  require 'codecov'
-  SimpleCov.formatter = SimpleCov::Formatter::Codecov
+  require 'simplecov-cobertura'
+  SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
 end
 
 $LOAD_PATH.unshift File.expand_path('../lib', __dir__)


### PR DESCRIPTION
## Proposed Changes

The Codecov Bash Uploader is deprecated - https://docs.codecov.com/docs/about-the-codecov-bash-uploader. We have to switch to new one - https://docs.codecov.com/docs/codecov-uploader.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `rake test` completes successfully
- [x] Commit messages are in [semantic format](https://seesparkbox.com/foundry/semantic_commit_messages)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
