### PR TITLE
chore(ci): add Ruby 3.1 to CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,6 +190,16 @@ workflows:
   build:
     jobs:
       - tests-ruby:
+          name: client-r3.1
+          ruby-image: "cimg/ruby:3.1"
+      - tests-ruby:
+          name: APIs-r3.1
+          ruby-image: "cimg/ruby:3.1"
+          gemspec-file: influxdb-client-apis.gemspec
+          path: ./apis
+          requires:
+            - client-r3.1
+      - tests-ruby:
           name: client-r3.0
           ruby-image: "cimg/ruby:3.0"
       - tests-ruby:
@@ -259,6 +269,7 @@ workflows:
             - client-jruby
       - deploy-all:
           requires:
+            - APIs-r3.1
             - APIs-r3.0
             - APIs-r2.7
             - APIs-r2.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Others
 1. [#108](https://github.com/influxdata/influxdb-client-ruby/pull/108): Use local repository for `influxdb-client-apis` development
 
+### CI
+1. [#109](https://github.com/influxdata/influxdb-client-ruby/pull/109): Add Ruby 3.1 into CI
+
 ## 2.6.0 [2022-06-24]
 
 ### Bug Fixes


### PR DESCRIPTION
## Proposed Changes

Add Ruby 3.1 to CI build.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
