### PR TITLE
feat: add FluxRecord.row with response data stored in Array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.8.0 [unreleased]
 
+### Features
+1. [#118](https://github.com/influxdata/influxdb-client-ruby/pull/118): Added `FluxRecord.row` which stores response data in a array
+
 ## 2.7.0 [2022-07-29]
 
 ### Features

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,3 +12,5 @@
 
 ## Others
 - [invokable_scripts.rb](invokable_scripts.rb) - How to use Invokable scripts Cloud API to create custom endpoints that query data
+- [record_row_example.rb](record_row_example.rb) - How to use FluxRecord.row (Array) instead of FluxRecord.values (Hash),
+  in case of duplicity column names

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,5 +12,5 @@
 
 ## Others
 - [invokable_scripts.rb](invokable_scripts.rb) - How to use Invokable scripts Cloud API to create custom endpoints that query data
-- [record_row_example.rb](record_row_example.rb) - How to use FluxRecord.row (Array) instead of FluxRecord.values (Hash),
+- [record_row_example.rb](record_row_example.rb) - How to use `FluxRecord.row` (Array) instead of `FluxRecord.values` (Hash),
   in case of duplicity column names

--- a/examples/record_row_example.rb
+++ b/examples/record_row_example.rb
@@ -1,0 +1,38 @@
+require 'influxdb-client'
+
+url = 'http://localhost:8086'
+token = 'my-token'
+bucket = 'my-bucket'
+org = 'my-org'
+
+client = InfluxDB2::Client.new(url,
+                               token,
+                               bucket: bucket,
+                               org: org,
+                               precision: InfluxDB2::WritePrecision::NANOSECOND,
+                               use_ssl: false)
+
+# Prepare Data
+write_api = client.create_write_api
+(1..5).each { |i|
+  write_api.write(data: "point,table=my-table result=#{i}", bucket: bucket, org: org)
+}
+
+# Query data with pivot
+query_api = client.create_query_api
+query = "from(bucket: \"#{bucket}\") |> range(start: -1m) |> filter(fn: (r) => (r[\"_measurement\"] == \"point\"))
+|> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")"
+result = query_api.query(query: query)
+
+# Write data to output
+puts "----------------------------------------------- FluxRecord.values ----------------------------------------------"
+result[0].records.each do |record|
+  puts record.values
+end
+
+puts "------------------------------------------------- FluxRecord.row -----------------------------------------------"
+result[0].records.each do |record|
+  puts record.row.join(",")
+end
+
+client.close!

--- a/examples/record_row_example.rb
+++ b/examples/record_row_example.rb
@@ -14,9 +14,9 @@ client = InfluxDB2::Client.new(url,
 
 # Prepare Data
 write_api = client.create_write_api
-(1..5).each { |i|
+(1..5).each do |i|
   write_api.write(data: "point,table=my-table result=#{i}", bucket: bucket, org: org)
-}
+end
 
 # Query data with pivot
 query_api = client.create_query_api
@@ -25,14 +25,14 @@ query = "from(bucket: \"#{bucket}\") |> range(start: -1m) |> filter(fn: (r) => (
 result = query_api.query(query: query)
 
 # Write data to output
-puts "----------------------------------------------- FluxRecord.values ----------------------------------------------"
+puts '----------------------------------------------- FluxRecord.values ----------------------------------------------'
 result[0].records.each do |record|
   puts record.values
 end
 
-puts "------------------------------------------------- FluxRecord.row -----------------------------------------------"
+puts '------------------------------------------------- FluxRecord.row -----------------------------------------------'
 result[0].records.each do |record|
-  puts record.row.join(",")
+  puts record.row.join(',')
 end
 
 client.close!

--- a/influxdb-client.gemspec
+++ b/influxdb-client.gemspec
@@ -24,15 +24,15 @@ require 'influxdb2/client/version'
 
 # noinspection DuplicatedCode
 Gem::Specification.new do |spec|
-  spec.name = 'influxdb-client'
-  spec.version = ENV['CIRCLE_BUILD_NUM'] ? "#{InfluxDB2::VERSION}-#{ENV['CIRCLE_BUILD_NUM']}" : InfluxDB2::VERSION
-  spec.authors = ['Jakub Bednar']
-  spec.email = ['jakub.bednar@gmail.com']
+  spec.name          = 'influxdb-client'
+  spec.version       = ENV['CIRCLE_BUILD_NUM'] ? "#{InfluxDB2::VERSION}-#{ENV['CIRCLE_BUILD_NUM']}" : InfluxDB2::VERSION
+  spec.authors       = ['Jakub Bednar']
+  spec.email         = ['jakub.bednar@gmail.com']
 
-  spec.summary = 'Ruby library for InfluxDB 2.'
-  spec.description = 'This is the official Ruby library for InfluxDB 2.'
-  spec.homepage = 'https://github.com/influxdata/influxdb-client-ruby'
-  spec.license = 'MIT'
+  spec.summary       = 'Ruby library for InfluxDB 2.'
+  spec.description   = 'This is the official Ruby library for InfluxDB 2.'
+  spec.homepage      = 'https://github.com/influxdata/influxdb-client-ruby'
+  spec.license       = 'MIT'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/influxdata/influxdb-client-ruby'
@@ -50,6 +50,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '~> 0.66.0'
   spec.add_development_dependency 'simplecov-cobertura', '~> 1.4.2'
-  spec.add_development_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
   spec.add_development_dependency 'webmock', '~> 3.7'
 end

--- a/influxdb-client.gemspec
+++ b/influxdb-client.gemspec
@@ -24,15 +24,15 @@ require 'influxdb2/client/version'
 
 # noinspection DuplicatedCode
 Gem::Specification.new do |spec|
-  spec.name          = 'influxdb-client'
-  spec.version       = ENV['CIRCLE_BUILD_NUM'] ? "#{InfluxDB2::VERSION}-#{ENV['CIRCLE_BUILD_NUM']}" : InfluxDB2::VERSION
-  spec.authors       = ['Jakub Bednar']
-  spec.email         = ['jakub.bednar@gmail.com']
+  spec.name = 'influxdb-client'
+  spec.version = ENV['CIRCLE_BUILD_NUM'] ? "#{InfluxDB2::VERSION}-#{ENV['CIRCLE_BUILD_NUM']}" : InfluxDB2::VERSION
+  spec.authors = ['Jakub Bednar']
+  spec.email = ['jakub.bednar@gmail.com']
 
-  spec.summary       = 'Ruby library for InfluxDB 2.'
-  spec.description   = 'This is the official Ruby library for InfluxDB 2.'
-  spec.homepage      = 'https://github.com/influxdata/influxdb-client-ruby'
-  spec.license       = 'MIT'
+  spec.summary = 'Ruby library for InfluxDB 2.'
+  spec.description = 'This is the official Ruby library for InfluxDB 2.'
+  spec.homepage = 'https://github.com/influxdata/influxdb-client-ruby'
+  spec.license = 'MIT'
 
   spec.metadata['homepage_uri'] = spec.homepage
   spec.metadata['source_code_uri'] = 'https://github.com/influxdata/influxdb-client-ruby'
@@ -50,6 +50,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rubocop', '~> 0.66.0'
   spec.add_development_dependency 'simplecov-cobertura', '~> 1.4.2'
-  spec.add_development_dependency 'webmock', '~> 3.7'
   spec.add_development_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
+  spec.add_development_dependency 'webmock', '~> 3.7'
 end

--- a/influxdb-client.gemspec
+++ b/influxdb-client.gemspec
@@ -51,4 +51,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.66.0'
   spec.add_development_dependency 'simplecov-cobertura', '~> 1.4.2'
   spec.add_development_dependency 'webmock', '~> 3.7'
+  spec.add_development_dependency 'typhoeus', '~> 1.0', '>= 1.0.1'
 end

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -190,8 +190,8 @@ module InfluxDB2
 
       duplicates = table.columns.group_by { :label }.select { |_k, v| v.size > 1 }
 
-      warning = "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}\nYou should use the
- 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash."
+      warning = "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}
+You should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash."
       puts warning unless duplicates.empty?
     end
 

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -192,7 +192,7 @@ module InfluxDB2
 
       warning = "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}\nYou should use the
  'FluxRecord.row to access your data instead of 'FluxRecord.values' hash."
-      put warning unless duplicates.empty?
+      puts warning unless duplicates.empty?
     end
 
     def _parse_values(csv)

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -126,7 +126,7 @@ module InfluxDB2
 
       # start new table
       if ((ANNOTATIONS.include? token) && !@start_new_table) ||
-         (@response_mode == InfluxDB2::FluxResponseMode::ONLY_NAMES && @table.nil?)
+        (@response_mode == InfluxDB2::FluxResponseMode::ONLY_NAMES && @table.nil?)
 
         # Return already parsed DataFrame
         @start_new_table = true
@@ -190,8 +190,9 @@ module InfluxDB2
 
       duplicates = table.columns.group_by { :label }.select { |_k, v| v.size > 1 }
 
-      puts "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}
-You should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash." unless duplicates.empty?
+      warning = "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}\nYou should use the
+ 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash."
+      put warning unless duplicates.empty?
     end
 
     def _parse_values(csv)

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -125,8 +125,8 @@ module InfluxDB2
       token = csv[0]
 
       # start new table
-      if ((ANNOTATIONS.include? token) && !@start_new_table) ||
-        (@response_mode == InfluxDB2::FluxResponseMode::ONLY_NAMES && @table.nil?)
+      if ((ANNOTATIONS.include? token) && !@start_new_table) || (@response_mode ==
+        InfluxDB2::FluxResponseMode::ONLY_NAMES && @table.nil?)
 
         # Return already parsed DataFrame
         @start_new_table = true

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -188,12 +188,10 @@ module InfluxDB2
         i += 1
       end
 
-      duplicates = table.columns.group_by { |e| e.label }.select { |k, v| v.size > 1 }
+      duplicates = table.columns.group_by { :label }.select { |_k, v| v.size > 1 }
 
-      if duplicates.length > 0
-        puts "The response contains columns with duplicated names: #{duplicates.keys.join(", ")}\n"
-        puts "You should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash."
-      end
+      puts "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}\nYou should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash." if !duplicates.empty?
+
     end
 
     def _parse_values(csv)

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -126,7 +126,7 @@ module InfluxDB2
 
       # start new table
       if ((ANNOTATIONS.include? token) && !@start_new_table) ||
-        (@response_mode == InfluxDB2::FluxResponseMode::ONLY_NAMES && @table.nil?)
+         (@response_mode == InfluxDB2::FluxResponseMode::ONLY_NAMES && @table.nil?)
 
         # Return already parsed DataFrame
         @start_new_table = true
@@ -190,8 +190,8 @@ module InfluxDB2
 
       duplicates = table.columns.group_by { :label }.select { |_k, v| v.size > 1 }
 
-      puts "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}\nYou should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash." if !duplicates.empty?
-
+      puts "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}
+You should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash." unless duplicates.empty?
     end
 
     def _parse_values(csv)

--- a/lib/influxdb2/client/flux_table.rb
+++ b/lib/influxdb2/client/flux_table.rb
@@ -26,6 +26,7 @@ module InfluxDB2
       @columns = []
       @records = []
     end
+
     attr_reader :columns, :records
 
     # A table's group key is subset of the entire columns dataset that assigned to the table.
@@ -46,11 +47,14 @@ module InfluxDB2
   class FluxRecord
     # @param [Integer] table the index of table which contains the record
     # @param [Hash] values tuple of values
-    def initialize(table, values: nil)
+    # @param [Array] row record columns
+    def initialize(table, values: nil, row: nil)
       @table = table
       @values = values || {}
+      @row = row || []
     end
-    attr_reader :table, :values
+
+    attr_reader :table, :values, :row
     attr_writer :table
 
     # @return [Time] the inclusive lower time bound of all records
@@ -93,6 +97,7 @@ module InfluxDB2
       @group = group
       @default_value = default_value
     end
+
     attr_reader :index, :label, :data_type, :group, :default_value
     attr_writer :index, :label, :data_type, :group, :default_value
   end

--- a/test/influxdb/flux_csv_parser_test.rb
+++ b/test/influxdb/flux_csv_parser_test.rb
@@ -506,4 +506,24 @@ class FluxCsvParserErrorTest < MiniTest::Test
     assert_equal '11', tables[0].records[0].values['value1']
     assert_equal 'west', tables[0].records[0].values['region']
   end
+
+  def test_parse_duplicate_column_names
+    data = '#datatype,string,long,dateTime:RFC3339,dateTime:RFC3339,dateTime:RFC3339,string,string,double
+#group,false,false,true,true,false,true,true,false
+#default,_result,,,,,,,
+ ,result,table,_start,_stop,_time,_measurement,location,result
+,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:33.746Z,my_measurement,Prague,25.3
+,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:39.299Z,my_measurement,Prague,25.3
+,,0,2022-09-13T06:14:40.469404272Z,2022-09-13T06:24:40.469404272Z,2022-09-13T06:24:40.454Z,my_measurement,Prague,25.3'
+
+    tables = InfluxDB2::FluxCsvParser.new(data, stream: false, response_mode: InfluxDB2::FluxResponseMode::ONLY_NAMES)
+                                     .parse
+                                     .tables
+    assert_equal 1, tables.size
+    assert_equal 8, tables[0].columns.size
+    assert_equal 3, tables[0].records.size
+    assert_equal 7, tables[0].records[0].values.size
+    assert_equal 8, tables[0].records[0].row.size
+    assert_equal 25.3, tables[0].records[0].row[7]
+  end
 end


### PR DESCRIPTION
## Proposed Changes

Adding possibility of accessing response data in Array FluxRecord.row.

In case of using pivot on data, where field contains labels that occur by default in the annotated CSV (f.e. "result" or "table"), could be duplicated column names in response. In that case FluxRecord.values (Hash), which can hold only unique keys, doesn't show complete data. This edge case is solved by using FluxRecord.row (Array).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
