### PR TITLE
chore(ci): migrate Scheduled workflow to Scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,6 +188,9 @@ jobs:
 workflows:
   version: 2
   build:
+    when:
+      not:
+        equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - tests-ruby:
           name: client-r3.1
@@ -282,13 +285,8 @@ workflows:
               only: master
 
   nightly:
-    triggers:
-      - schedule:
-          cron: "0 0 * * *"
-          filters:
-            branches:
-              only:
-                - master
+    when:
+      equal: [ scheduled_pipeline, << pipeline.trigger_source >> ]
     jobs:
       - tests-ruby
       - check-generate-sources


### PR DESCRIPTION
## Proposed Changes

The **Scheduled Workflows** uses client for nightly builds but the scheduled workflows will be phased out by the end of 2022. The CircleCI's configuration has to be migrate to **Scheduled pipelines**.

- https://circleci.com/docs/workflows/#scheduling-a-workflow
- https://circleci.com/docs/scheduled-pipelines/#migrate-scheduled-workflows

Configured trigger:
![image](https://user-images.githubusercontent.com/455137/194829468-993722b3-e550-47a2-b2c2-764fc23071c5.png)


## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] Rebased/mergeable
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
