### PR TITLE
fix: duplicate columns warning shows in improper situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 2.9.0 [unreleased]
 
+### Bug Fixes
+1. [#123](https://github.com/influxdata/influxdb-client-ruby/pull/123): Duplicate columns warning shows in improper situations
+
 ## 2.8.0 [2022-10-27]
 
 ### Features

--- a/lib/influxdb2/client/client.rb
+++ b/lib/influxdb2/client/client.rb
@@ -51,7 +51,6 @@ module InfluxDB2
     # @option options [Logger] :logger Logger used for logging. Disable logging by set to false.
     # @option options [bool] :debugging Enable debugging for HTTP request/response.
     # @option options [Hash] :tags Default tags which will be added to each point written by api.
-    #   the body line-protocol
     def initialize(url, token, options = nil)
       @auto_closeable = []
       @options = options ? options.dup : {}

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -188,7 +188,7 @@ module InfluxDB2
         i += 1
       end
 
-      duplicates = table.columns.group_by { :label }.select { |_k, v| v.size > 1 }
+      duplicates = table.columns.group_by(&:label).select { |_k, v| v.size > 1 }
 
       warning = "The response contains columns with duplicated names: #{duplicates.keys.join(', ')}
 You should use the 'FluxRecord.row to access your data instead of 'FluxRecord.values' hash."


### PR DESCRIPTION
## Proposed Changes

The duplicated columns warning shows in improper situations - always 😞.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
