### PR TITLE
fix: `query` return type is `Array`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 1. [#123](https://github.com/influxdata/influxdb-client-ruby/pull/123): Duplicate columns warning shows in improper situations
+1. [#124](https://github.com/influxdata/influxdb-client-ruby/pull/124): Query return type is `Array` instead of `Hash`
 
 ## 2.8.0 [2022-10-27]
 

--- a/lib/influxdb2/client/flux_csv_parser.rb
+++ b/lib/influxdb2/client/flux_csv_parser.rb
@@ -60,7 +60,7 @@ module InfluxDB2
     def initialize(response, stream: false, response_mode: InfluxDB2::FluxResponseMode::FULL)
       @response = response
       @stream = stream
-      @tables = {}
+      @tables = []
 
       @table_index = 0
       @table_id = -1

--- a/test/influxdb/query_api_test.rb
+++ b/test/influxdb/query_api_test.rb
@@ -144,4 +144,22 @@ class QueryApiTest < MiniTest::Test
     assert_requested(:post, 'http://localhost:8086/api/v2/query?org=my-org',
                      times: 1, headers: headers)
   end
+
+  def test_query_result_type
+    stub_request(:post, 'http://localhost:8086/api/v2/query?org=my-org')
+      .to_return(body: SUCCESS_DATA)
+
+    client = InfluxDB2::Client.new('http://localhost:8086', 'my-token',
+                                   bucket: 'my-bucket',
+                                   org: 'my-org',
+                                   use_ssl: false)
+
+    bucket = 'my-bucket'
+    result = client.create_query_api
+                   .query(query: "from(bucket:\"#{bucket}\") |> range(start: 1970-01-01T00:00:00.000000001Z) |> last()")
+
+    assert_equal 1, result.length
+    assert_equal 4, result[0].records.length
+    assert_equal Array, result.class
+  end
 end


### PR DESCRIPTION
Closes #122

## Proposed Changes

Fixed return types for `query` method.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
