### PR TITLE
feat: client can be used as a resource

### DIFF
--- a/.rubocop-cops.yml
+++ b/.rubocop-cops.yml
@@ -28,6 +28,8 @@ Metrics/LineLength:
   Max: 120
 Metrics/MethodLength:
   Max: 50
+Metrics/BlockLength:
+  Max: 50
 Metrics/ClassLength:
   Max: 300
 Metrics/AbcSize:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,10 @@
 ## 2.9.0 [unreleased]
 
 :warning: The client can be used as a resource:
-    ```ruby
+
     InfluxDB2::Client.use('https://localhost:8086', 'my-token') do |client|
         client.do_something
     end
-    ```
 
 ### Features
 1. [#126](https://github.com/influxdata/influxdb-client-ruby/pull/126): Add `Task` API

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 ## 2.9.0 [unreleased]
 
+:warning: The client can be used as a resource:
+
+    InfluxDB2::Client.use('https://localhost:8086', 'my-token') do |client|
+        client.do_something
+    end
+
 ### Features
 1. [#126](https://github.com/influxdata/influxdb-client-ruby/pull/126): Add `Task` API
+1. [#127](https://github.com/influxdata/influxdb-client-ruby/pull/127): Client can be used as a resource
 
 ### Bug Fixes
 1. [#123](https://github.com/influxdata/influxdb-client-ruby/pull/123): Duplicate columns warning shows in improper situations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 ## 2.9.0 [unreleased]
 
 :warning: The client can be used as a resource:
-
+    ```ruby
     InfluxDB2::Client.use('https://localhost:8086', 'my-token') do |client|
         client.do_something
     end
+    ```
 
 ### Features
 1. [#126](https://github.com/influxdata/influxdb-client-ruby/pull/126): Add `Task` API

--- a/examples/create_new_bucket.rb
+++ b/examples/create_new_bucket.rb
@@ -49,8 +49,10 @@ InfluxDB2::Client.use(url,
   authorization = InfluxDB2::API::Authorization.new(description: "Authorization to read/write bucket: #{bucket.name}",
                                                     org_id: organization.id,
                                                     permissions: [
-                                                      InfluxDB2::API::Permission.new(action: 'read', resource: resource),
-                                                      InfluxDB2::API::Permission.new(action: 'write', resource: resource)
+                                                      InfluxDB2::API::Permission.new(action: 'read',
+                                                                                     resource: resource),
+                                                      InfluxDB2::API::Permission.new(action: 'write',
+                                                                                     resource: resource)
                                                     ])
   result = api.create_authorizations_api
               .post_authorizations(authorization)

--- a/examples/create_new_bucket.rb
+++ b/examples/create_new_bucket.rb
@@ -13,48 +13,47 @@ bucket = 'my-bucket'
 org = 'my-org'
 token = 'my-token'
 
-client = InfluxDB2::Client.new(url,
-                               token,
-                               bucket: bucket,
-                               org: org,
-                               use_ssl: false,
-                               precision: InfluxDB2::WritePrecision::NANOSECOND)
+InfluxDB2::Client.use(url,
+                      token,
+                      bucket: bucket,
+                      org: org,
+                      use_ssl: false,
+                      precision: InfluxDB2::WritePrecision::NANOSECOND) do |client|
 
-api = InfluxDB2::API::Client.new(client)
+  api = InfluxDB2::API::Client.new(client)
 
-# Find my organization
-organization = api.create_organizations_api
-                  .get_orgs
-                  .orgs
-                  .select { |it| it.name == 'my-org' }
-                  .first
+  # Find my organization
+  organization = api.create_organizations_api
+                    .get_orgs
+                    .orgs
+                    .select { |it| it.name == 'my-org' }
+                    .first
 
-#
-# Create new Bucket
-#
-retention_rule = InfluxDB2::API::RetentionRule.new(type: 'expire', every_seconds: 3600)
-bucket_name = 'new-bucket-name'
-request = InfluxDB2::API::PostBucketRequest.new(org_id: organization.id,
-                                                name: bucket_name,
-                                                retention_rules: [retention_rule])
-bucket = api.create_buckets_api
-            .post_buckets(request)
+  #
+  # Create new Bucket
+  #
+  retention_rule = InfluxDB2::API::RetentionRule.new(type: 'expire', every_seconds: 3600)
+  bucket_name = 'new-bucket-name'
+  request = InfluxDB2::API::PostBucketRequest.new(org_id: organization.id,
+                                                  name: bucket_name,
+                                                  retention_rules: [retention_rule])
+  bucket = api.create_buckets_api
+              .post_buckets(request)
 
-#
-# Create Permission to read/write from Bucket
-#
-resource = InfluxDB2::API::Resource.new(type: 'buckets',
-                                        id: bucket.id,
-                                        org_id: organization.id)
-authorization = InfluxDB2::API::Authorization.new(description: "Authorization to read/write bucket: #{bucket.name}",
-                                                  org_id: organization.id,
-                                                  permissions: [
-                                                    InfluxDB2::API::Permission.new(action: 'read', resource: resource),
-                                                    InfluxDB2::API::Permission.new(action: 'write', resource: resource)
-                                                  ])
-result = api.create_authorizations_api
-            .post_authorizations(authorization)
+  #
+  # Create Permission to read/write from Bucket
+  #
+  resource = InfluxDB2::API::Resource.new(type: 'buckets',
+                                          id: bucket.id,
+                                          org_id: organization.id)
+  authorization = InfluxDB2::API::Authorization.new(description: "Authorization to read/write bucket: #{bucket.name}",
+                                                    org_id: organization.id,
+                                                    permissions: [
+                                                      InfluxDB2::API::Permission.new(action: 'read', resource: resource),
+                                                      InfluxDB2::API::Permission.new(action: 'write', resource: resource)
+                                                    ])
+  result = api.create_authorizations_api
+              .post_authorizations(authorization)
 
-print("The token: '#{result.token}' is authorized to read/write from/to bucket: '#{bucket.name}'.")
-
-client.close!
+  print("The token: '#{result.token}' is authorized to read/write from/to bucket: '#{bucket.name}'.")
+end

--- a/examples/influxdb_18_example.rb
+++ b/examples/influxdb_18_example.rb
@@ -9,27 +9,26 @@ retention_policy = 'autogen'
 
 bucket = "#{database}/#{retention_policy}"
 
-client = InfluxDB2::Client.new('http://localhost:8086',
-                               "#{username}:#{password}",
-                               bucket: bucket,
-                               org: '-',
-                               use_ssl: false,
-                               precision: InfluxDB2::WritePrecision::NANOSECOND)
+InfluxDB2::Client.use('http://localhost:8086',
+                      "#{username}:#{password}",
+                      bucket: bucket,
+                      org: '-',
+                      use_ssl: false,
+                      precision: InfluxDB2::WritePrecision::NANOSECOND) do |client|
 
-puts '*** Write Points ***'
+  puts '*** Write Points ***'
 
-write_api = client.create_write_api
-point = InfluxDB2::Point.new(name: 'mem')
-                        .add_tag('host', 'host1')
-                        .add_field('used_percent', 21.43234543)
-puts point.to_line_protocol
-write_api.write(data: point)
+  write_api = client.create_write_api
+  point = InfluxDB2::Point.new(name: 'mem')
+                          .add_tag('host', 'host1')
+                          .add_field('used_percent', 21.43234543)
+  puts point.to_line_protocol
+  write_api.write(data: point)
 
-puts '*** Query Points ***'
+  puts '*** Query Points ***'
 
-query_api = client.create_query_api
-query = "from(bucket: \"#{bucket}\") |> range(start: -1h)"
-result = query_api.query(query: query)
-result[0].records.each { |record| puts "#{record.time} #{record.measurement}: #{record.field} #{record.value}" }
-
-client.close!
+  query_api = client.create_query_api
+  query = "from(bucket: \"#{bucket}\") |> range(start: -1h)"
+  result = query_api.query(query: query)
+  result[0].records.each { |record| puts "#{record.time} #{record.measurement}: #{record.field} #{record.value}" }
+end

--- a/examples/invokable_scripts.rb
+++ b/examples/invokable_scripts.rb
@@ -8,83 +8,87 @@ token = '...'
 bucket = '...'
 org = '...'
 
-client = InfluxDB2::Client.new(url, token, bucket: bucket, org: org, precision: InfluxDB2::WritePrecision::NANOSECOND)
+InfluxDB2::Client.use(url,
+                      token,
+                      bucket: bucket,
+                      org: org,
+                      precision: InfluxDB2::WritePrecision::NANOSECOND) do |client|
 
-unique_id = Time.now.utc.to_i.to_s
-#
-# Prepare data
-#
-point1 = InfluxDB2::Point.new(name: 'my_measurement')
-                         .add_tag('location', 'Prague')
-                         .add_field('temperature', 25.3)
-point2 = InfluxDB2::Point.new(name: 'my_measurement')
-                         .add_tag('location', 'New York')
-                         .add_field('temperature', 24.3)
-client.create_write_api.write(data: [point1, point2])
+  unique_id = Time.now.utc.to_i.to_s
+  #
+  # Prepare data
+  #
+  point1 = InfluxDB2::Point.new(name: 'my_measurement')
+                           .add_tag('location', 'Prague')
+                           .add_field('temperature', 25.3)
+  point2 = InfluxDB2::Point.new(name: 'my_measurement')
+                           .add_tag('location', 'New York')
+                           .add_field('temperature', 24.3)
+  client.create_write_api.write(data: [point1, point2])
 
-scripts_api = client.create_invokable_scripts_api
+  scripts_api = client.create_invokable_scripts_api
 
-#
-# Create Invokable Script
-#
-puts "------- Create -------\n"
-script_query = 'from(bucket: params.bucket_name) |> range(start: -30d) |> limit(n:2)'
-create_request = InfluxDB2::ScriptCreateRequest.new(name: "my_script_#{unique_id}",
-                                                    description: 'my first try',
-                                                    language: InfluxDB2::ScriptLanguage::FLUX,
-                                                    script: script_query)
+  #
+  # Create Invokable Script
+  #
+  puts "------- Create -------\n"
+  script_query = 'from(bucket: params.bucket_name) |> range(start: -30d) |> limit(n:2)'
+  create_request = InfluxDB2::ScriptCreateRequest.new(name: "my_script_#{unique_id}",
+                                                      description: 'my first try',
+                                                      language: InfluxDB2::ScriptLanguage::FLUX,
+                                                      script: script_query)
 
-created_script = scripts_api.create_script(create_request)
-puts created_script.inspect
+  created_script = scripts_api.create_script(create_request)
+  puts created_script.inspect
 
-#
-# Update Invokable Script
-#
-puts "------- Update -------\n"
-update_request = InfluxDB2::ScriptUpdateRequest.new(description: 'my updated description')
-created_script = scripts_api.update_script(created_script.id, update_request)
-puts created_script.inspect
+  #
+  # Update Invokable Script
+  #
+  puts "------- Update -------\n"
+  update_request = InfluxDB2::ScriptUpdateRequest.new(description: 'my updated description')
+  created_script = scripts_api.update_script(created_script.id, update_request)
+  puts created_script.inspect
 
-#
-# Invoke a script
-#
+  #
+  # Invoke a script
+  #
 
-# FluxTables
-puts "\n------- Invoke to FluxTables -------\n"
-tables = scripts_api.invoke_script(created_script.id, params: { 'bucket_name' => bucket })
-tables.each do |_, table|
-  table.records.each do |record|
+  # FluxTables
+  puts "\n------- Invoke to FluxTables -------\n"
+  tables = scripts_api.invoke_script(created_script.id, params: { 'bucket_name' => bucket })
+  tables.each do |_, table|
+    table.records.each do |record|
+      puts "#{record.time} #{record.values['location']}: #{record.field} #{record.value}"
+    end
+  end
+
+  # Stream of FluxRecords
+  puts "\n------- Invoke to Stream of FluxRecords -------\n"
+  records = scripts_api.invoke_script_stream(created_script.id, params: { 'bucket_name' => bucket })
+  records.each do |record|
     puts "#{record.time} #{record.values['location']}: #{record.field} #{record.value}"
   end
+
+  # RAW
+  puts "\n------- Invoke to Raw-------\n"
+  raw = scripts_api.invoke_script_raw(created_script.id, params: { 'bucket_name' => bucket })
+  puts "RAW output:\n #{raw}"
+
+  #
+  # List scripts
+  #
+  puts "\n------- List -------\n"
+  scripts = scripts_api.find_scripts
+  scripts.each do |script|
+    puts " ---\n ID: #{script.id}\n Name: #{script.name}\n Description: #{script.description}"
+  end
+  puts '---'
+
+  #
+  # Delete previously created Script
+  #
+  puts "------- Delete -------\n"
+  scripts_api.delete_script(created_script.id)
+  puts " Successfully deleted script: '#{created_script.name}'"
+
 end
-
-# Stream of FluxRecords
-puts "\n------- Invoke to Stream of FluxRecords -------\n"
-records = scripts_api.invoke_script_stream(created_script.id, params: { 'bucket_name' => bucket })
-records.each do |record|
-  puts "#{record.time} #{record.values['location']}: #{record.field} #{record.value}"
-end
-
-# RAW
-puts "\n------- Invoke to Raw-------\n"
-raw = scripts_api.invoke_script_raw(created_script.id, params: { 'bucket_name' => bucket })
-puts "RAW output:\n #{raw}"
-
-#
-# List scripts
-#
-puts "\n------- List -------\n"
-scripts = scripts_api.find_scripts
-scripts.each do |script|
-  puts " ---\n ID: #{script.id}\n Name: #{script.name}\n Description: #{script.description}"
-end
-puts '---'
-
-#
-# Delete previously created Script
-#
-puts "------- Delete -------\n"
-scripts_api.delete_script(created_script.id)
-puts " Successfully deleted script: '#{created_script.name}'"
-
-client.close!

--- a/examples/invokable_scripts.rb
+++ b/examples/invokable_scripts.rb
@@ -90,5 +90,4 @@ InfluxDB2::Client.use(url,
   puts "------- Delete -------\n"
   scripts_api.delete_script(created_script.id)
   puts " Successfully deleted script: '#{created_script.name}'"
-
 end

--- a/examples/parameterized_query.rb
+++ b/examples/parameterized_query.rb
@@ -8,27 +8,27 @@ token = 'my-token'
 bucket = 'my-bucket'
 org = 'my-org'
 
-client = InfluxDB2::Client.new(url,
-                               token,
-                               bucket: bucket,
-                               org: org,
-                               precision: InfluxDB2::WritePrecision::NANOSECOND)
+InfluxDB2::Client.new(url,
+                      token,
+                      bucket: bucket,
+                      org: org,
+                      precision: InfluxDB2::WritePrecision::NANOSECOND) do |client|
 
-puts '*** Write Points ***'
+  puts '*** Write Points ***'
 
-write_api = client.create_write_api
-point = InfluxDB2::Point.new(name: 'weather')
-                        .add_tag('location', 'Praque')
-                        .add_field('temperature', 21)
-puts point.to_line_protocol
-write_api.write(data: point)
+  write_api = client.create_write_api
+  point = InfluxDB2::Point.new(name: 'weather')
+                          .add_tag('location', 'Praque')
+                          .add_field('temperature', 21)
+  puts point.to_line_protocol
+  write_api.write(data: point)
 
-puts '*** Query Points ***'
+  puts '*** Query Points ***'
 
-query_api = client.create_query_api
-query = 'from(bucket: params.bucketParam) |> range(start: duration(v: params.startParam))'
-params = { 'bucketParam' => 'my-bucket', 'startParam' => '-1h' }
-result = query_api.query(query: query, params: params)
-result[0].records.each { |record| puts "#{record.time} #{record.measurement}: #{record.field} #{record.value}" }
+  query_api = client.create_query_api
+  query = 'from(bucket: params.bucketParam) |> range(start: duration(v: params.startParam))'
+  params = { 'bucketParam' => 'my-bucket', 'startParam' => '-1h' }
+  result = query_api.query(query: query, params: params)
+  result[0].records.each { |record| puts "#{record.time} #{record.measurement}: #{record.field} #{record.value}" }
 
-client.close!
+end

--- a/examples/parameterized_query.rb
+++ b/examples/parameterized_query.rb
@@ -30,5 +30,4 @@ InfluxDB2::Client.new(url,
   params = { 'bucketParam' => 'my-bucket', 'startParam' => '-1h' }
   result = query_api.query(query: query, params: params)
   result[0].records.each { |record| puts "#{record.time} #{record.measurement}: #{record.field} #{record.value}" }
-
 end

--- a/examples/record_row_example.rb
+++ b/examples/record_row_example.rb
@@ -25,12 +25,12 @@ InfluxDB2::Client.new(url,
   result = query_api.query(query: query)
 
   # Write data to output
-  puts '----------------------------------------------- FluxRecord.values ----------------------------------------------'
+  puts '---------------------------------------------- FluxRecord.values ---------------------------------------------'
   result[0].records.each do |record|
     puts record.values
   end
 
-  puts '------------------------------------------------- FluxRecord.row -----------------------------------------------'
+  puts '------------------------------------------------ FluxRecord.row ----------------------------------------------'
   result[0].records.each do |record|
     puts record.row.join(',')
   end

--- a/examples/record_row_example.rb
+++ b/examples/record_row_example.rb
@@ -5,34 +5,33 @@ token = 'my-token'
 bucket = 'my-bucket'
 org = 'my-org'
 
-client = InfluxDB2::Client.new(url,
-                               token,
-                               bucket: bucket,
-                               org: org,
-                               precision: InfluxDB2::WritePrecision::NANOSECOND,
-                               use_ssl: false)
+InfluxDB2::Client.new(url,
+                      token,
+                      bucket: bucket,
+                      org: org,
+                      precision: InfluxDB2::WritePrecision::NANOSECOND,
+                      use_ssl: false) do |client|
 
-# Prepare Data
-write_api = client.create_write_api
-(1..5).each do |i|
-  write_api.write(data: "point,table=my-table result=#{i}", bucket: bucket, org: org)
-end
+  # Prepare Data
+  write_api = client.create_write_api
+  (1..5).each do |i|
+    write_api.write(data: "point,table=my-table result=#{i}", bucket: bucket, org: org)
+  end
 
-# Query data with pivot
-query_api = client.create_query_api
-query = "from(bucket: \"#{bucket}\") |> range(start: -1m) |> filter(fn: (r) => (r[\"_measurement\"] == \"point\"))
+  # Query data with pivot
+  query_api = client.create_query_api
+  query = "from(bucket: \"#{bucket}\") |> range(start: -1m) |> filter(fn: (r) => (r[\"_measurement\"] == \"point\"))
 |> pivot(rowKey:[\"_time\"], columnKey: [\"_field\"], valueColumn: \"_value\")"
-result = query_api.query(query: query)
+  result = query_api.query(query: query)
 
-# Write data to output
-puts '----------------------------------------------- FluxRecord.values ----------------------------------------------'
-result[0].records.each do |record|
-  puts record.values
+  # Write data to output
+  puts '----------------------------------------------- FluxRecord.values ----------------------------------------------'
+  result[0].records.each do |record|
+    puts record.values
+  end
+
+  puts '------------------------------------------------- FluxRecord.row -----------------------------------------------'
+  result[0].records.each do |record|
+    puts record.row.join(',')
+  end
 end
-
-puts '------------------------------------------------- FluxRecord.row -----------------------------------------------'
-result[0].records.each do |record|
-  puts record.row.join(',')
-end
-
-client.close!

--- a/lib/influxdb2/client/client.rb
+++ b/lib/influxdb2/client/client.rb
@@ -63,6 +63,23 @@ module InfluxDB2
       at_exit { close! }
     end
 
+    # Instantiate a new InfluxDB client with code block. The client will be passed as an argument
+    # and will be automatically closed when the block terminates.
+    #
+    # It takes same args as {InfluxDB2::Client#initialize}.
+    #
+    # @example Instantiate a client.
+    #   InfluxDBClient::Client.use(url: 'https://localhost:8086', token: 'my-token') do |client|
+    #     ping = client.ping
+    #     puts ping.version
+    #   end
+    def self.use(*args)
+      client = Client.new(*args)
+      yield client
+    ensure
+      client.close!
+    end
+
     # Write time series data into InfluxDB thought WriteApi.
     #
     # @return [WriteApi] New instance of WriteApi.

--- a/test/influxdb/client_test.rb
+++ b/test/influxdb/client_test.rb
@@ -126,4 +126,32 @@ class ClientTest < Minitest::Test
 
     assert_match 'authorization: ***', output.string
   end
+
+  def test_resource
+    InfluxDB2::Client.use('http://localhost:8086', 'my-token', use_ssl: false) do |client|
+      ping = client.ping
+      assert_equal 'ok', ping.status
+    end
+  end
+
+  def test_resource_closed
+    client = nil
+    InfluxDB2::Client.use('http://localhost:8086', 'my-token', use_ssl: false) do |resource|
+      client = resource
+    end
+    assert_equal true, client.instance_variable_get(:@closed)
+  end
+
+  def test_resource_closed_error
+    client = nil
+    begin
+      InfluxDB2::Client.use('http://localhost:8086', 'my-token', use_ssl: false) do |resource|
+        client = resource
+        raise 'Just for testing.'
+      end
+    rescue StandardError => e
+      puts e
+    end
+    assert_equal true, client.instance_variable_get(:@closed)
+  end
 end


### PR DESCRIPTION
Closes #120

## Proposed Changes

The **InfluxDB::Client** can be also used as a resource:

```ruby
InfluxDB2::Client.use('https://localhost:8086', 'my-token') do |client|
  client.do_something
end
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
