### PR TITLE
chore(deps): change `dependabot` interval to `monthly`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   - package-ecosystem: "bundler"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 10
   - package-ecosystem: "bundler"
     directory: "apis"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Proposed Changes

Changed `dependabot` interval to `monthly`. The security updates aren't affected by this change.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
