### PR TITLE
fix: escape timestamps for fields and tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 2.10.0 [unreleased]
+## 3.0.0 [unreleased]
+
+### Bug Fixes
+1. [#131](https://github.com/influxdata/influxdb-client-ruby/pull/131): Convert time objects present in fields to integer. Prior to this change the timestamps were converted to strings
 
 ## 2.9.0 [2022-12-01]
 

--- a/lib/influxdb2/client/point.rb
+++ b/lib/influxdb2/client/point.rb
@@ -127,7 +127,7 @@ module InfluxDB2
       return nil if fields.empty?
 
       line_protocol << " #{fields}" if fields
-      timestamp = _escape_time
+      timestamp = _escape_time(@time)
       line_protocol << " #{timestamp}" if timestamp
 
       line_protocol
@@ -185,6 +185,8 @@ module InfluxDB2
         '"'.freeze + result + '"'.freeze
       elsif value.is_a?(Integer)
         "#{value}i"
+      elsif value.is_a?(Time)
+        "#{_escape_time(value)}i"
       elsif [Float::INFINITY, -Float::INFINITY].include?(value)
         ''
       else
@@ -192,16 +194,16 @@ module InfluxDB2
       end
     end
 
-    def _escape_time
-      if @time.nil?
+    def _escape_time(value)
+      if value.nil?
         nil
-      elsif @time.is_a?(Integer)
-        @time.to_s
-      elsif @time.is_a?(Float)
-        @time.round.to_s
-      elsif @time.is_a?(Time)
-        nano_seconds = @time.to_i * 1e9
-        nano_seconds += @time.tv_nsec
+      elsif value.is_a?(Integer)
+        value.to_s
+      elsif value.is_a?(Float)
+        value.round.to_s
+      elsif value.is_a?(Time)
+        nano_seconds = value.to_i * 1e9
+        nano_seconds += value.tv_nsec
         case @precision || DEFAULT_WRITE_PRECISION
         when InfluxDB2::WritePrecision::MILLISECOND then
           (nano_seconds / 1e6).round
@@ -213,7 +215,7 @@ module InfluxDB2
           nano_seconds.round
         end
       else
-        @time.to_s
+        value.to_s
       end
     end
   end

--- a/lib/influxdb2/client/version.rb
+++ b/lib/influxdb2/client/version.rb
@@ -19,5 +19,5 @@
 # THE SOFTWARE.
 
 module InfluxDB2
-  VERSION = '2.10.0'.freeze
+  VERSION = '3.0.0'.freeze
 end

--- a/test/influxdb/point_test.rb
+++ b/test/influxdb/point_test.rb
@@ -64,6 +64,7 @@ class PointTest < MiniTest::Test
   end
 
   def test_field_types
+    time = Time.utc(2023, 11, 1)
     point = InfluxDB2::Point.new(name: 'h2o')
                             .add_tag('tag_b', 'b')
                             .add_tag('tag_a', 'a')
@@ -73,8 +74,10 @@ class PointTest < MiniTest::Test
                             .add_field('n4', 5.5)
                             .add_field('bool', true)
                             .add_field('string', 'string value')
+                            .add_field('started', time)
 
-    expected = 'h2o,tag_a=a,tag_b=b bool=true,n1=-2i,n2=10i,n3=1265437718438866624512i,n4=5.5,string="string value"'
+    expected = 'h2o,tag_a=a,tag_b=b bool=true,n1=-2i,n2=10i,n3=1265437718438866624512i,n4=5.5,'\
+               'started=1698796800000000000i,string="string value"'
     assert_equal expected, point.to_line_protocol
   end
 


### PR DESCRIPTION
## Proposed Changes

_Briefly describe your proposed changes:_ Timestamps present in fields and tags are not converted into integers. They should be converted. This PR handles that and converts timestamps from tags and fields into integers. This change is required for [influxdb-rails 2.0](https://github.com/influxdata/influxdb-rails).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
