### PR TITLE
fix: support influxdb v1.8 HTTP error response message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 3.1.0 [unreleased]
 
+### Bug Fixes
+1. [#134](https://github.com/influxdata/influxdb-client-ruby/pull/134): Support influxdb v1.8 HTTP error response message. Prior to this change, in case of an HTTP error response (influxDB v1.8) the InfluxError had empty message.
+
 ## 3.0.0 [2023-12-05]
 
 ### Bug Fixes

--- a/lib/influxdb2/client/influx_error.rb
+++ b/lib/influxdb2/client/influx_error.rb
@@ -32,7 +32,7 @@ module InfluxDB2
 
     def self.from_response(response)
       json = JSON.parse(response.body)
-      obj = new(message: json['message'] || '', code: response.code, reference: json['code'] || '',
+      obj = new(message: json['message'] || json['error'] || '', code: response.code, reference: json['code'] || '',
                 retry_after: response['Retry-After'] || '')
       obj
     rescue JSON::ParserError


### PR DESCRIPTION
An influxdb v1.8 HTTP error response message was not correctly transferred to ruby InfluxError message. Hence, in case of an InfuxDB v1.8 Error response, the reason (except status code) was not traceable.

Closes #133

## Proposed Changes

After parsing the response body of an InfuxDB Error response, the information of it is wrapped into an `InfluxDB2::InfluxError`.
Evaluation of the error message has to be different for InfluxDB v1.8 and InfuxDB v2.x, because the response body is different.

How the fix works:
- InfluxDB v2.x uses the `message` key for this
- InfluxDB v1.8 uses the `error` key for this

-> previously only `message` was supported
-> now, in case `message` is blank, `error` is checked

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
