### PR TITLE
chore(deps): add csv dependency as required by ruby 3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 3.2.0 [unreleased]
 
+### Others
+1. [#137](https://github.com/influxdata/influxdb-client-ruby/pull/137): Add the csv gem to the gemspec dependencies.
+
 ## 3.1.0 [2024-03-01]
 
 ### Bug Fixes

--- a/influxdb-client.gemspec
+++ b/influxdb-client.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 2.2.0'
 
+  spec.add_dependency 'csv'
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'minitest', '5.15.0'
   spec.add_development_dependency 'minitest-reporters', '~> 1.4'


### PR DESCRIPTION
Closes #136

## Proposed Changes

Add the csv gem to the gemspec dependencies.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] `rake test` completes successfully
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
